### PR TITLE
fix(cli): recursive chown of target/ after non-reproducible Docker build

### DIFF
--- a/shade-agent-cli/src/commands/deploy/near.js
+++ b/shade-agent-cli/src/commands/deploy/near.js
@@ -228,13 +228,13 @@ export async function deployCustomContractFromSource() {
 
     const wasmPath = resolveWasmPath(absoluteSourcePath);
 
-    // Fix file ownership after Docker creates it (Docker runs as root, files owned by root)
+    // Fix file ownership after Docker creates them 
     if (!reproducible && process.platform === "linux") {
       const uid = process.getuid();
       const gid = process.getgid();
       runWithSudoOnLinux(
         "chown",
-        [`${uid}:${gid}`, wasmPath],
+        ["-R", `${uid}:${gid}`, path.join(absoluteSourcePath, "target")],
         { stdio: "pipe" },
       );
     }


### PR DESCRIPTION
The Linux non-reproducible build runs cargo near inside a Docker container as root, so the entire target/ tree ends up root-owned. The post-build chown only fixed the WASM file itself; reading it from JS still failed with EACCES because the calling user couldn't traverse the root-owned target/ and target/near/ parent directories.

Switch to chown -R on target/ so the user owns the file and every parent it has to walk through.