### PR TITLE
refactor(shade-agent-js): Remove deriveHashForTEE

### DIFF
--- a/shade-agent-js/src/api.ts
+++ b/shade-agent-js/src/api.ts
@@ -79,7 +79,7 @@ export class ShadeClient {
   private agentAccountId: string;
   private agentPrivateKeys: string[];
   private currentKeyIndex: number;
-  private keysDerivedWithTEE: boolean; // true if all keys were derived with TEE entropy, false otherwise
+  private keysDerivedWithRandom: boolean; // true if all keys were derived from CSPRNG, false if any came from a derivation path
   private keysChecked: boolean; // true if the number of keys have been checked (happens on the first call), false otherwise
 
   // Private constructor so only `create()` can be used to create an instance
@@ -88,14 +88,14 @@ export class ShadeClient {
     dstackClient: DstackClient | undefined,
     accountId: string,
     agentPrivateKeys: string[],
-    keysDerivedWithTEE: boolean,
+    keysDerivedWithRandom: boolean,
   ) {
     this.config = config;
     this.dstackClient = dstackClient;
     this.agentAccountId = accountId;
     this.agentPrivateKeys = agentPrivateKeys;
     this.currentKeyIndex = 0;
-    this.keysDerivedWithTEE = keysDerivedWithTEE;
+    this.keysDerivedWithRandom = keysDerivedWithRandom;
     this.keysChecked = false;
   }
 
@@ -115,7 +115,7 @@ export class ShadeClient {
 
       // Generate agent account ID and private key
       const agentPrivateKeys: string[] = [];
-      const { accountId, agentPrivateKey, derivedWithTEE } =
+      const { accountId, agentPrivateKey, derivedWithRandom } =
         await generateAgent(dstackClient, config.derivationPath);
       agentPrivateKeys.push(agentPrivateKey);
 
@@ -124,7 +124,7 @@ export class ShadeClient {
         dstackClient,
         accountId,
         agentPrivateKeys,
-        derivedWithTEE,
+        derivedWithRandom,
       );
     } catch (error) {
       throw toThrowable(error);
@@ -181,7 +181,7 @@ export class ShadeClient {
       const contractAttestation = await internalGetAttestation(
         this.dstackClient,
         this.agentAccountId,
-        this.keysDerivedWithTEE,
+        this.keysDerivedWithRandom,
       );
 
       let depositYocto: bigint;
@@ -277,7 +277,7 @@ export class ShadeClient {
         this.config.numKeys!,
         this.dstackClient,
         this.config.derivationPath,
-        this.keysDerivedWithTEE,
+        this.keysDerivedWithRandom,
         this.keysChecked,
       );
       this.agentPrivateKeys.push(...keysToAdd);
@@ -320,7 +320,7 @@ export class ShadeClient {
       return await internalGetAttestation(
         this.dstackClient,
         this.agentAccountId,
-        this.keysDerivedWithTEE,
+        this.keysDerivedWithRandom,
       );
     } catch (error) {
       throw toThrowable(error);

--- a/shade-agent-js/src/api.ts
+++ b/shade-agent-js/src/api.ts
@@ -111,6 +111,7 @@ export class ShadeClient {
       await validateShadeConfig(config);
 
       // Detect if running in a TEE
+      // This is called once so will be in TEE or not in TEE the whole time
       const dstackClient = await getDstackClient();
 
       // Generate agent account ID and private key

--- a/shade-agent-js/src/utils/agent.ts
+++ b/shade-agent-js/src/utils/agent.ts
@@ -6,7 +6,7 @@ import type { KeyPairSigner } from "@near-js/signers";
 import { addKeysToAccount, removeKeysFromAccount } from "./near";
 import { Account } from "@near-js/accounts";
 import { Provider } from "@near-js/providers";
-import { genericError, safeParseSigner, toThrowable, withRetry } from "./errors";
+import { genericError, safeParseSigner, toThrowable } from "./errors";
 
 // Generates an agent account ID and private key
 export async function generateAgent(
@@ -15,10 +15,10 @@ export async function generateAgent(
 ): Promise<{
   accountId: string;
   agentPrivateKey: string;
-  derivedWithTEE: boolean;
+  derivedWithRandom: boolean;
 }> {
   try {
-    const { hash, usedTEE } = await deriveHash(dstackClient, derivationPath);
+    const { hash, usedRandom } = deriveHash(dstackClient, derivationPath);
     const seedInfo = generateSeedPhrase(hash);
 
     const accountId = Buffer.from(PublicKey.from(seedInfo.publicKey).data)
@@ -28,89 +28,43 @@ export async function generateAgent(
     return {
       accountId,
       agentPrivateKey: seedInfo.secretKey,
-      derivedWithTEE: usedTEE,
+      derivedWithRandom: usedRandom,
     };
   } catch (error) {
     throw toThrowable(error);
   }
 }
 
-// Derives a hash from a derivation path (for deterministic key generation)
+// Derives a hash from a derivation path (for deterministic key generation in local mode)
 function deriveHashFromPath(derivationPath: string): Buffer {
   return createHash("sha256").update(Buffer.from(derivationPath)).digest();
 }
 
-// Derives a hash from random data (for non-TEE)
+// 32 bytes of CSPRNG entropy
 function deriveHashFromRandom(): Buffer {
-  const randomArray = new Uint8Array(32);
-  crypto.getRandomValues(randomArray);
-  const randomString = Buffer.from(randomArray).toString("hex");
-  return createHash("sha256").update(Buffer.from(randomString)).digest();
+  return Buffer.from(crypto.getRandomValues(new Uint8Array(32)));
 }
 
-// Derives a hash for TEE. The dstack `getKey` call is retried on transient
-// socket / TEE hiccups.
-async function deriveHashForTEE(dstackClient: DstackClient): Promise<Buffer> {
-  try {
-    // JS crypto random
-    const randomArray = new Uint8Array(32);
-    crypto.getRandomValues(randomArray);
-    const randomString = Buffer.from(randomArray).toString("hex");
-
-    const keyFromTee = (await withRetry(() => dstackClient.getKey(randomString)))
-      .key;
-
-    // Hash of JS crypto random and Phala key provider
-    return Buffer.from(
-      await crypto.subtle.digest(
-        "SHA-256",
-        Buffer.concat([randomArray, keyFromTee]),
-      ),
-    );
-  } catch (error) {
-    throw toThrowable(error);
-  }
-}
-
-// Derives a hash based on the environment (TEE, derivation path, or random)
-async function deriveHash(
+// In a TEE the derivationPath is ignored — only random-derived keys are
+// permitted to produce a real attestation (see internalGetAttestation).
+function deriveHash(
   dstackClient: DstackClient | undefined,
   derivationPath: string | undefined,
-): Promise<{ hash: Buffer; usedTEE: boolean }> {
-  try {
-    let hash: Buffer;
-    let usedTEE: boolean;
-
-    if (!dstackClient && derivationPath) {
-      // If not in a TEE and a derivation path is provided, use it to generate the hash
-      // if different users use the same derivation path, they will get the same account ID
-      // so they should generate it to be unique
-      hash = deriveHashFromPath(derivationPath);
-      usedTEE = false;
-    } else if (!dstackClient && !derivationPath) {
-      // If it is not in a TEE and no derivation path is provided, generate a random hash
-      hash = deriveHashFromRandom();
-      usedTEE = false;
-    } else {
-      // If it is in a TEE generate a hash from the Phala key provider and JS crypto random
-      hash = await deriveHashForTEE(dstackClient);
-      usedTEE = true;
-    }
-
-    return { hash, usedTEE };
-  } catch (error) {
-    throw toThrowable(error);
+): { hash: Buffer; usedRandom: boolean } {
+  if (!dstackClient && derivationPath) {
+    return { hash: deriveHashFromPath(derivationPath), usedRandom: false };
   }
+  return { hash: deriveHashFromRandom(), usedRandom: true };
 }
 
-// Manages the setup of additional keys for the agent account
-// Derives keys, adds missing ones, and removes excess keys as needed
+// Manages the setup of additional keys for the agent account.
+// Derives keys, adds missing ones, and removes excess keys as needed.
 export async function manageKeySetup(
   agentAccount: Account,
   numAdditionalKeys: number, // Number of additional keys to derive (not total)
   dstackClient: DstackClient | undefined,
   derivationPath: string | undefined,
-): Promise<{ keysToSave: string[]; allDerivedWithTEE: boolean }> {
+): Promise<{ keysToSave: string[]; allDerivedWithRandom: boolean }> {
   try {
     // Get the number of keys on the account already
     const keysOnAccount = await agentAccount.getAccessKeyList();
@@ -122,7 +76,7 @@ export async function manageKeySetup(
       numAdditionalKeys,
       numExistingAdditionalKeys,
     );
-    const { keys, allDerivedWithTEE } = await deriveAdditionalKeys(
+    const { keys, allDerivedWithRandom } = await deriveAdditionalKeys(
       numKeysToDerive,
       dstackClient,
       derivationPath,
@@ -145,8 +99,8 @@ export async function manageKeySetup(
     const keysToSave = keys.slice(0, numAdditionalKeys);
 
     return {
-      keysToSave: keysToSave,
-      allDerivedWithTEE,
+      keysToSave,
+      allDerivedWithRandom,
     };
   } catch (error) {
     throw toThrowable(error);
@@ -158,34 +112,28 @@ async function deriveAdditionalKeys(
   numKeys: number,
   dstackClient: DstackClient | undefined,
   derivationPath: string | undefined,
-): Promise<{ keys: string[]; allDerivedWithTEE: boolean }> {
+): Promise<{ keys: string[]; allDerivedWithRandom: boolean }> {
   try {
     // Generate numKeys additional keys
-    // Run all derivations in parallel for better performance for TEE
     const keyPromises = Array.from({ length: numKeys }, async (_, index) => {
       const i = index + 1; // Start from 1
       // For additional keys with derivation path, append key index
       const keyDerivationPath = derivationPath
         ? `${derivationPath}-${i}`
         : undefined;
-      const { hash, usedTEE } = await deriveHash(
-        dstackClient,
-        keyDerivationPath,
-      );
+      const { hash, usedRandom } = deriveHash(dstackClient, keyDerivationPath);
       const seedInfo = generateSeedPhrase(hash);
-      // Return both the key and whether it was derived with TEE
       return {
         key: seedInfo.secretKey,
-        derivedWithTEE: usedTEE,
+        usedRandom,
       };
     });
 
     const results = await Promise.all(keyPromises);
-    const keys = results.map((r) => r.key);
-    // Check if all keys were derived with TEE
-    const allDerivedWithTEE = results.every((r) => r.derivedWithTEE);
-
-    return { keys, allDerivedWithTEE };
+    return {
+      keys: results.map((r) => r.key),
+      allDerivedWithRandom: results.every((r) => r.usedRandom),
+    };
   } catch (error) {
     throw toThrowable(error);
   }
@@ -227,7 +175,7 @@ export async function ensureKeysSetup(
   numKeys: number,
   dstackClient: DstackClient | undefined,
   derivationPath: string | undefined,
-  keysDerivedWithTEE: boolean,
+  keysDerivedWithRandom: boolean,
   keysChecked: boolean,
 ): Promise<{ keysToAdd: string[]; wasChecked: boolean }> {
   try {
@@ -237,19 +185,17 @@ export async function ensureKeysSetup(
 
     const signer = safeParseSigner(agentPrivateKeys[0]);
     const agentAccount = new Account(agentAccountId, rpc, signer);
-    const { keysToSave, allDerivedWithTEE } = await manageKeySetup(
+    const { keysToSave, allDerivedWithRandom } = await manageKeySetup(
       agentAccount,
       numKeys - 1,
       dstackClient,
       derivationPath,
     );
 
-    if (!allDerivedWithTEE) {
-      if (keysDerivedWithTEE) {
-        throw genericError(
-          "First key was derived with TEE but additional keys were not. Something went wrong with the key derivation.",
-        );
-      }
+    if (allDerivedWithRandom !== keysDerivedWithRandom) {
+      throw genericError(
+        "First key and additional keys disagree on derivation method. Something went wrong with the key derivation.",
+      );
     }
 
     return { keysToAdd: keysToSave, wasChecked: true };

--- a/shade-agent-js/src/utils/agent.ts
+++ b/shade-agent-js/src/utils/agent.ts
@@ -71,6 +71,15 @@ export async function manageKeySetup(
     const numKeysOnAccount = keysOnAccount.keys.length;
     const numExistingAdditionalKeys = numKeysOnAccount - 1; // Subtract the first key
 
+    // Random-mode derivation cannot reproduce previous keys, so we cannot
+    // reconcile against any existing additional keys on the account.
+    const inRandomMode = !!dstackClient || !derivationPath;
+    if (inRandomMode && numExistingAdditionalKeys > 0) {
+      throw genericError(
+        `Account has ${numExistingAdditionalKeys} additional key(s) that cannot be reused in random-derivation mode. Set a derivationPath (local) or use a fresh account.`,
+      );
+    }
+
     // Derive keys using the higher number (needed for both adding and removing cases)
     const numKeysToDerive = Math.max(
       numAdditionalKeys,

--- a/shade-agent-js/src/utils/agent.ts
+++ b/shade-agent-js/src/utils/agent.ts
@@ -64,7 +64,8 @@ export async function manageKeySetup(
   numAdditionalKeys: number, // Number of additional keys to derive (not total)
   dstackClient: DstackClient | undefined,
   derivationPath: string | undefined,
-): Promise<{ keysToSave: string[]; allDerivedWithRandom: boolean }> {
+  keysDerivedWithRandom: boolean,
+): Promise<{ keysToSave: string[] }> {
   try {
     // Get the number of keys on the account already
     const keysOnAccount = await agentAccount.getAccessKeyList();
@@ -91,6 +92,15 @@ export async function manageKeySetup(
       derivationPath,
     );
 
+    // Validate derivation-mode consistency before mutating chain state. If the
+    // first key and additional keys disagree, the account must stay untouched
+    // so a retry can recover without orphaned keys on chain.
+    if (allDerivedWithRandom !== keysDerivedWithRandom) {
+      throw genericError(
+        "First key and additional keys disagree on derivation method. Something went wrong with the key derivation.",
+      );
+    }
+
     if (numExistingAdditionalKeys < numAdditionalKeys) {
       // Need to add keys
       const keysToAdd = keys.slice(
@@ -109,7 +119,6 @@ export async function manageKeySetup(
 
     return {
       keysToSave,
-      allDerivedWithRandom,
     };
   } catch (error) {
     throw toThrowable(error);
@@ -126,7 +135,7 @@ async function deriveAdditionalKeys(
     // Generate numKeys additional keys
     const keyPromises = Array.from({ length: numKeys }, async (_, index) => {
       const i = index + 1; // Start from 1
-      // For additional keys with derivation path, append key index
+      // For local mode with deriviation path append key index to deriviation path so its deterministic 
       const keyDerivationPath = derivationPath
         ? `${derivationPath}-${i}`
         : undefined;
@@ -194,18 +203,13 @@ export async function ensureKeysSetup(
 
     const signer = safeParseSigner(agentPrivateKeys[0]);
     const agentAccount = new Account(agentAccountId, rpc, signer);
-    const { keysToSave, allDerivedWithRandom } = await manageKeySetup(
+    const { keysToSave } = await manageKeySetup(
       agentAccount,
       numKeys - 1,
       dstackClient,
       derivationPath,
+      keysDerivedWithRandom,
     );
-
-    if (allDerivedWithRandom !== keysDerivedWithRandom) {
-      throw genericError(
-        "First key and additional keys disagree on derivation method. Something went wrong with the key derivation.",
-      );
-    }
 
     return { keysToAdd: keysToSave, wasChecked: true };
   } catch (error) {

--- a/shade-agent-js/src/utils/tee.ts
+++ b/shade-agent-js/src/utils/tee.ts
@@ -93,11 +93,13 @@ export async function getDstackClient(): Promise<DstackClient | undefined> {
 export async function internalGetAttestation(
   dstackClient: DstackClient | undefined,
   agentAccountId: string,
-  keysDerivedWithTEE: boolean,
+  keysDerivedWithRandom: boolean,
 ): Promise<DstackAttestationForContract> {
-  if (!dstackClient || !keysDerivedWithTEE) {
-    // If not in a TEE or keys were not derived with TEE, return a fake/empty attestation.
-    // The contract will accept this if requires_tee is false, or reject it if requires_tee is true.
+  if (!dstackClient || !keysDerivedWithRandom) {
+    // No TEE, or any key was path-derived (local-mode only).
+    // Path-derived keys are blocked from producing a real attestation because
+    // the same path produces the same account ID across callers.
+    // The contract accepts this fake if requires_tee is false, rejects it otherwise.
     return getFakeAttestation();
   }
 

--- a/shade-agent-js/src/utils/tee.ts
+++ b/shade-agent-js/src/utils/tee.ts
@@ -72,6 +72,7 @@ interface QuoteCollateralResponse {
 // then it will generate a deterministic account ID for the agent.
 // This could be dangerous, however, it will not be able to register in the contract
 // as it will not provide the attestation, which is required for registration.
+// Regardless getDstackClient is only called once during setup of the client 
 export async function getDstackClient(): Promise<DstackClient | undefined> {
   // First check if socket exists
   if (!existsSync("/var/run/dstack.sock")) {

--- a/shade-agent-js/tests/unit/agent.test.ts
+++ b/shade-agent-js/tests/unit/agent.test.ts
@@ -112,7 +112,7 @@ describe("agent utils", () => {
         mockAccount as any,
         1,
         undefined,
-        undefined,
+        "test-path",
       );
 
       expect(removeKeysFromAccount).toHaveBeenCalledWith(
@@ -132,7 +132,7 @@ describe("agent utils", () => {
         mockAccount as any,
         1,
         undefined,
-        undefined,
+        "test-path",
       );
 
       expect(addKeysToAccount).not.toHaveBeenCalled();
@@ -162,8 +162,24 @@ describe("agent utils", () => {
       );
 
       await expect(
-        manageKeySetup(mockAccount as any, 1, undefined, undefined),
+        manageKeySetup(mockAccount as any, 1, undefined, "test-path"),
       ).rejects.toThrow("Remove keys failed");
+    });
+
+    it("should throw when in random mode and account has existing additional keys", async () => {
+      const mockAccount = createMockAccountWithKeys([
+        { public_key: "key1" },
+        { public_key: "key2" },
+      ]);
+
+      // No dstackClient + no derivationPath = random mode. Existing additional
+      // key cannot be reused because random derivation produces fresh keys.
+      await expect(
+        manageKeySetup(mockAccount as any, 1, undefined, undefined),
+      ).rejects.toThrow(/cannot be reused in random-derivation mode/);
+
+      expect(addKeysToAccount).not.toHaveBeenCalled();
+      expect(removeKeysFromAccount).not.toHaveBeenCalled();
     });
 
     it("should derive with random when dstackClient is provided (path ignored)", async () => {
@@ -201,7 +217,12 @@ describe("agent utils", () => {
       const mockAccount = createMockAccountWithKeys([{ public_key: "key1" }]);
       const derivationPath = "test-path";
 
-      await manageKeySetup(mockAccount as any, 3, undefined, derivationPath);
+      const result = await manageKeySetup(
+        mockAccount as any,
+        3,
+        undefined,
+        derivationPath,
+      );
       expect(addKeysToAccount).toHaveBeenCalled();
       const keys = vi.mocked(addKeysToAccount).mock.calls[0][1] as string[];
 
@@ -210,6 +231,7 @@ describe("agent utils", () => {
       expect(keys[0]).not.toBe(keys[1]);
       expect(keys[0]).not.toBe(keys[2]);
       expect(keys[1]).not.toBe(keys[2]);
+      expect(result.allDerivedWithRandom).toBe(false);
     });
 
     it("should generate unique keys when adding multiple keys without derivation path", async () => {

--- a/shade-agent-js/tests/unit/agent.test.ts
+++ b/shade-agent-js/tests/unit/agent.test.ts
@@ -91,6 +91,7 @@ describe("agent utils", () => {
         2,
         undefined,
         undefined,
+        true,
       );
 
       expect(addKeysToAccount).toHaveBeenCalledWith(
@@ -98,7 +99,6 @@ describe("agent utils", () => {
         expect.arrayContaining([expect.any(String), expect.any(String)]),
       );
       expect(result.keysToSave).toHaveLength(2);
-      expect(result.allDerivedWithRandom).toBe(true);
     });
 
     it("should remove keys when account has more keys than needed", async () => {
@@ -113,6 +113,7 @@ describe("agent utils", () => {
         1,
         undefined,
         "test-path",
+        false,
       );
 
       expect(removeKeysFromAccount).toHaveBeenCalledWith(
@@ -133,6 +134,7 @@ describe("agent utils", () => {
         1,
         undefined,
         "test-path",
+        false,
       );
 
       expect(addKeysToAccount).not.toHaveBeenCalled();
@@ -147,7 +149,7 @@ describe("agent utils", () => {
       );
 
       await expect(
-        manageKeySetup(mockAccount as any, 2, undefined, undefined),
+        manageKeySetup(mockAccount as any, 2, undefined, undefined, true),
       ).rejects.toThrow("Add keys failed");
     });
 
@@ -162,7 +164,7 @@ describe("agent utils", () => {
       );
 
       await expect(
-        manageKeySetup(mockAccount as any, 1, undefined, "test-path"),
+        manageKeySetup(mockAccount as any, 1, undefined, "test-path", false),
       ).rejects.toThrow("Remove keys failed");
     });
 
@@ -175,8 +177,23 @@ describe("agent utils", () => {
       // No dstackClient + no derivationPath = random mode. Existing additional
       // key cannot be reused because random derivation produces fresh keys.
       await expect(
-        manageKeySetup(mockAccount as any, 1, undefined, undefined),
+        manageKeySetup(mockAccount as any, 1, undefined, undefined, true),
       ).rejects.toThrow(/cannot be reused in random-derivation mode/);
+
+      expect(addKeysToAccount).not.toHaveBeenCalled();
+      expect(removeKeysFromAccount).not.toHaveBeenCalled();
+    });
+
+    it("should throw without touching chain state when derivation mode disagrees with claim", async () => {
+      const mockAccount = createMockAccountWithKeys([{ public_key: "key1" }]);
+
+      // Caller claims first key was random-derived, but passes derivationPath
+      // (no dstackClient) which produces deterministic additional keys.
+      await expect(
+        manageKeySetup(mockAccount as any, 2, undefined, "test-path", true),
+      ).rejects.toThrow(
+        "First key and additional keys disagree on derivation method",
+      );
 
       expect(addKeysToAccount).not.toHaveBeenCalled();
       expect(removeKeysFromAccount).not.toHaveBeenCalled();
@@ -186,14 +203,14 @@ describe("agent utils", () => {
       const dstackClient = createMockDstackClient();
       const mockAccount = createMockAccountWithKeys([{ public_key: "key1" }]);
 
-      const result = await manageKeySetup(
+      await manageKeySetup(
         mockAccount as any,
         1,
         dstackClient,
         "ignored-in-tee",
+        true,
       );
 
-      expect(result.allDerivedWithRandom).toBe(true);
       // dstack getKey is no longer called — entropy comes purely from CSPRNG.
       expect(dstackClient.getKey).not.toHaveBeenCalled();
     });
@@ -202,7 +219,13 @@ describe("agent utils", () => {
       const dstackClient = createMockDstackClient();
       const mockAccount = createMockAccountWithKeys([{ public_key: "key1" }]);
 
-      await manageKeySetup(mockAccount as any, 3, dstackClient, undefined);
+      await manageKeySetup(
+        mockAccount as any,
+        3,
+        dstackClient,
+        undefined,
+        true,
+      );
       expect(addKeysToAccount).toHaveBeenCalled();
       const keys = vi.mocked(addKeysToAccount).mock.calls[0][1] as string[];
 
@@ -217,11 +240,12 @@ describe("agent utils", () => {
       const mockAccount = createMockAccountWithKeys([{ public_key: "key1" }]);
       const derivationPath = "test-path";
 
-      const result = await manageKeySetup(
+      await manageKeySetup(
         mockAccount as any,
         3,
         undefined,
         derivationPath,
+        false,
       );
       expect(addKeysToAccount).toHaveBeenCalled();
       const keys = vi.mocked(addKeysToAccount).mock.calls[0][1] as string[];
@@ -231,13 +255,12 @@ describe("agent utils", () => {
       expect(keys[0]).not.toBe(keys[1]);
       expect(keys[0]).not.toBe(keys[2]);
       expect(keys[1]).not.toBe(keys[2]);
-      expect(result.allDerivedWithRandom).toBe(false);
     });
 
     it("should generate unique keys when adding multiple keys without derivation path", async () => {
       const mockAccount = createMockAccountWithKeys([{ public_key: "key1" }]);
 
-      await manageKeySetup(mockAccount as any, 3, undefined, undefined);
+      await manageKeySetup(mockAccount as any, 3, undefined, undefined, true);
       expect(addKeysToAccount).toHaveBeenCalled();
       const keys = vi.mocked(addKeysToAccount).mock.calls[0][1] as string[];
 
@@ -265,13 +288,25 @@ describe("agent utils", () => {
       const mockAccount1 = createMockAccountWithKeys([{ public_key: "key1" }]);
       const mockAccount2 = createMockAccountWithKeys([{ public_key: "key1" }]);
 
-      await manageKeySetup(mockAccount1 as any, 2, dstackClient1, undefined);
+      await manageKeySetup(
+        mockAccount1 as any,
+        2,
+        dstackClient1,
+        undefined,
+        true,
+      );
       const additionalKeys1 = vi.mocked(addKeysToAccount).mock
         .calls[0][1] as string[];
 
       vi.clearAllMocks();
 
-      await manageKeySetup(mockAccount2 as any, 2, dstackClient2, undefined);
+      await manageKeySetup(
+        mockAccount2 as any,
+        2,
+        dstackClient2,
+        undefined,
+        true,
+      );
       const additionalKeys2 = vi.mocked(addKeysToAccount).mock
         .calls[0][1] as string[];
 
@@ -293,13 +328,13 @@ describe("agent utils", () => {
       const mockAccount1 = createMockAccountWithKeys([{ public_key: "key1" }]);
       const mockAccount2 = createMockAccountWithKeys([{ public_key: "key1" }]);
 
-      await manageKeySetup(mockAccount1 as any, 2, undefined, undefined);
+      await manageKeySetup(mockAccount1 as any, 2, undefined, undefined, true);
       const additionalKeys1 = vi.mocked(addKeysToAccount).mock
         .calls[0][1] as string[];
 
       vi.clearAllMocks();
 
-      await manageKeySetup(mockAccount2 as any, 2, undefined, undefined);
+      await manageKeySetup(mockAccount2 as any, 2, undefined, undefined, true);
       const additionalKeys2 = vi.mocked(addKeysToAccount).mock
         .calls[0][1] as string[];
 
@@ -323,13 +358,25 @@ describe("agent utils", () => {
       const mockAccount1 = createMockAccountWithKeys([{ public_key: "key1" }]);
       const mockAccount2 = createMockAccountWithKeys([{ public_key: "key1" }]);
 
-      await manageKeySetup(mockAccount1 as any, 2, undefined, derivationPath);
+      await manageKeySetup(
+        mockAccount1 as any,
+        2,
+        undefined,
+        derivationPath,
+        false,
+      );
       const additionalKeys1 = vi.mocked(addKeysToAccount).mock
         .calls[0][1] as string[];
 
       vi.clearAllMocks();
 
-      await manageKeySetup(mockAccount2 as any, 2, undefined, derivationPath);
+      await manageKeySetup(
+        mockAccount2 as any,
+        2,
+        undefined,
+        derivationPath,
+        false,
+      );
       const additionalKeys2 = vi.mocked(addKeysToAccount).mock
         .calls[0][1] as string[];
 
@@ -354,13 +401,25 @@ describe("agent utils", () => {
       const mockAccount1 = createMockAccountWithKeys([{ public_key: "key1" }]);
       const mockAccount2 = createMockAccountWithKeys([{ public_key: "key1" }]);
 
-      await manageKeySetup(mockAccount1 as any, 2, undefined, derivationPath1);
+      await manageKeySetup(
+        mockAccount1 as any,
+        2,
+        undefined,
+        derivationPath1,
+        false,
+      );
       const additionalKeys1 = vi.mocked(addKeysToAccount).mock
         .calls[0][1] as string[];
 
       vi.clearAllMocks();
 
-      await manageKeySetup(mockAccount2 as any, 2, undefined, derivationPath2);
+      await manageKeySetup(
+        mockAccount2 as any,
+        2,
+        undefined,
+        derivationPath2,
+        false,
+      );
       const additionalKeys2 = vi.mocked(addKeysToAccount).mock
         .calls[0][1] as string[];
 
@@ -481,6 +540,11 @@ describe("agent utils", () => {
       ).rejects.toThrow(
         "First key and additional keys disagree on derivation method",
       );
+
+      // Hardening invariant: chain state must remain untouched when the
+      // consistency check fires, so a retry can recover without orphaned keys.
+      expect(addKeysToAccount).not.toHaveBeenCalled();
+      expect(removeKeysFromAccount).not.toHaveBeenCalled();
     });
 
     it("should not throw when both first and additional keys are CSPRNG-derived (TEE)", async () => {

--- a/shade-agent-js/tests/unit/agent.test.ts
+++ b/shade-agent-js/tests/unit/agent.test.ts
@@ -56,7 +56,7 @@ describe("agent utils", () => {
       expect(result).toHaveProperty("accountId");
       expect(result.accountId).toMatch(/^[0-9a-f]{64}$/); // 32 bytes = 64 hex chars
       expect(result.agentPrivateKey).toMatch(/^ed25519:/);
-      expect(result).toHaveProperty("derivedWithTEE", false);
+      expect(result).toHaveProperty("derivedWithRandom", false);
     });
 
     it("should generate agent with random hash when no TEE and no derivation path", async () => {
@@ -65,30 +65,20 @@ describe("agent utils", () => {
       expect(result).toHaveProperty("accountId");
       expect(result.accountId).toMatch(/^[0-9a-f]{64}$/); // 32 bytes = 64 hex chars
       expect(result.agentPrivateKey).toMatch(/^ed25519:/);
-      expect(result).toHaveProperty("derivedWithTEE", false);
+      expect(result).toHaveProperty("derivedWithRandom", true);
     });
 
-    it("should generate agent with TEE when dstackClient is provided", async () => {
+    it("should generate agent with random hash when in TEE (path is ignored)", async () => {
       const dstackClient = createMockDstackClient();
 
-      const result = await generateAgent(dstackClient, undefined);
+      const result = await generateAgent(dstackClient, "ignored-in-tee");
 
       expect(result).toHaveProperty("accountId");
       expect(result.accountId).toMatch(/^[0-9a-f]{64}$/); // 32 bytes = 64 hex chars
       expect(result.agentPrivateKey).toMatch(/^ed25519:/);
-      expect(result).toHaveProperty("derivedWithTEE", true);
-      expect(dstackClient.getKey).toHaveBeenCalled();
-    });
-
-    it("should rethrow sanitised when TEE getKey fails", async () => {
-      const dstackClient = createMockDstackClient();
-      vi.mocked(dstackClient.getKey).mockRejectedValue(
-        new Error("TEE unavailable"),
-      );
-
-      await expect(generateAgent(dstackClient, undefined)).rejects.toThrow(
-        "TEE unavailable",
-      );
+      expect(result).toHaveProperty("derivedWithRandom", true);
+      // dstack getKey is no longer called — entropy comes purely from CSPRNG.
+      expect(dstackClient.getKey).not.toHaveBeenCalled();
     });
   });
 
@@ -108,7 +98,7 @@ describe("agent utils", () => {
         expect.arrayContaining([expect.any(String), expect.any(String)]),
       );
       expect(result.keysToSave).toHaveLength(2);
-      expect(result.allDerivedWithTEE).toBe(false);
+      expect(result.allDerivedWithRandom).toBe(true);
     });
 
     it("should remove keys when account has more keys than needed", async () => {
@@ -176,7 +166,7 @@ describe("agent utils", () => {
       ).rejects.toThrow("Remove keys failed");
     });
 
-    it("should use TEE when dstackClient is provided", async () => {
+    it("should derive with random when dstackClient is provided (path ignored)", async () => {
       const dstackClient = createMockDstackClient();
       const mockAccount = createMockAccountWithKeys([{ public_key: "key1" }]);
 
@@ -184,11 +174,12 @@ describe("agent utils", () => {
         mockAccount as any,
         1,
         dstackClient,
-        undefined,
+        "ignored-in-tee",
       );
 
-      expect(result.allDerivedWithTEE).toBe(true);
-      expect(dstackClient.getKey).toHaveBeenCalled();
+      expect(result.allDerivedWithRandom).toBe(true);
+      // dstack getKey is no longer called — entropy comes purely from CSPRNG.
+      expect(dstackClient.getKey).not.toHaveBeenCalled();
     });
 
     it("should generate unique keys when adding multiple keys with TEE", async () => {
@@ -406,7 +397,7 @@ describe("agent utils", () => {
         1,
         undefined,
         undefined,
-        false,
+        true,
         true, // keysChecked = true
       );
 
@@ -434,7 +425,7 @@ describe("agent utils", () => {
         2,
         undefined,
         undefined,
-        false,
+        true,
         false,
       );
 
@@ -447,14 +438,11 @@ describe("agent utils", () => {
       );
     });
 
-    it("should throw error when first key was TEE but additional keys are not", async () => {
+    it("should throw error when first key was random but additional keys were path-derived", async () => {
       const mockProvider = createMockProvider();
       const mockAccount = createMockAccountWithKeys([{ public_key: "key1" }]);
 
-      // Generate a valid test key
       const testKey = generateTestKey("test-key");
-
-      // Set global mock account so Account constructor uses it
       globalMockAccount = mockAccount;
 
       await expect(
@@ -463,25 +451,22 @@ describe("agent utils", () => {
           [testKey],
           mockProvider,
           2,
-          undefined, // No TEE client, so additional keys won't use TEE
-          undefined,
-          true, // First key was derived with TEE
+          undefined, // no TEE
+          "some-path", // path → additional keys deterministic → allDerivedWithRandom=false
+          true, // first key claims it was derived with random
           false,
         ),
       ).rejects.toThrow(
-        "First key was derived with TEE but additional keys were not",
+        "First key and additional keys disagree on derivation method",
       );
     });
 
-    it("should not throw error when both first and additional keys use TEE", async () => {
+    it("should not throw when both first and additional keys are CSPRNG-derived (TEE)", async () => {
       const dstackClient = createMockDstackClient();
       const mockProvider = createMockProvider();
       const mockAccount = createMockAccountWithKeys([{ public_key: "key1" }]);
 
-      // Generate a valid test key
       const testKey = generateTestKey("test-key");
-
-      // Set global mock account so Account constructor uses it
       globalMockAccount = mockAccount;
 
       const result = await ensureKeysSetup(
@@ -496,17 +481,15 @@ describe("agent utils", () => {
       );
 
       expect(result.wasChecked).toBe(true);
-      expect(dstackClient.getKey).toHaveBeenCalled();
+      // dstack getKey is no longer called — entropy comes purely from CSPRNG.
+      expect(dstackClient.getKey).not.toHaveBeenCalled();
     });
 
-    it("should not throw error when no keys use TEE", async () => {
+    it("should not throw when both first and additional keys are path-derived (local)", async () => {
       const mockProvider = createMockProvider();
       const mockAccount = createMockAccountWithKeys([{ public_key: "key1" }]);
 
-      // Generate a valid test key
       const testKey = generateTestKey("test-key");
-
-      // Set global mock account so Account constructor uses it
       globalMockAccount = mockAccount;
 
       const result = await ensureKeysSetup(
@@ -515,8 +498,8 @@ describe("agent utils", () => {
         mockProvider,
         2,
         undefined,
-        undefined,
-        false,
+        "shared-path",
+        false, // first key was path-derived
         false,
       );
 

--- a/shade-agent-js/tests/unit/api.test.ts
+++ b/shade-agent-js/tests/unit/api.test.ts
@@ -438,6 +438,41 @@ describe("ShadeClient", () => {
 
       await expect(client.register()).rejects.toThrow("Network error");
     });
+
+    it("no-TEE + derivationPath sends fake attestation (gate fires)", async () => {
+      const teeActual = await vi.importActual<typeof import("../../src/utils/tee")>(
+        "../../src/utils/tee",
+      );
+      const { getFakeAttestation } = await import(
+        "../../src/utils/attestation-transform"
+      );
+
+      setupClientMocks({ derivedWithRandom: false });
+      vi.mocked(internalGetAttestation).mockImplementation(
+        teeActual.internalGetAttestation,
+      );
+      (mockAccount.callFunction as ReturnType<typeof vi.fn>).mockResolvedValue(
+        true,
+      );
+      (mockProvider.callFunction as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+        null,
+      );
+
+      const client = await ShadeClient.create({
+        agentContractId: "agent.contract.testnet",
+        rpc: mockProvider,
+        derivationPath: "mysecret",
+      });
+
+      await client.register();
+
+      expect(mockAccount.callFunction).toHaveBeenCalledWith(
+        expect.objectContaining({
+          methodName: "register_agent",
+          args: { attestation: getFakeAttestation() },
+        }),
+      );
+    });
   });
 
   describe("view", () => {
@@ -718,6 +753,35 @@ describe("ShadeClient", () => {
       await expect(client.getAttestation()).rejects.toThrow(
         "Quote fetch failed",
       );
+    });
+
+    it("valid TEE client + any path-derived key returns fake attestation (defense-in-depth)", async () => {
+      // Simulates: keys aggregate to allDerivedWithRandom=false (e.g. mixed
+      // random + deterministic). Even with a working dstackClient, the gate
+      // must refuse to produce a real attestation and must never touch the
+      // TEE — no info(), no getQuote().
+      const teeActual = await vi.importActual<typeof import("../../src/utils/tee")>(
+        "../../src/utils/tee",
+      );
+      const { getFakeAttestation } = await import(
+        "../../src/utils/attestation-transform"
+      );
+
+      setupClientMocks({
+        dstackClient: mockDstackClient,
+        derivedWithRandom: false,
+      });
+      vi.mocked(internalGetAttestation).mockImplementation(
+        teeActual.internalGetAttestation,
+      );
+
+      const client = await ShadeClient.create({});
+
+      const result = await client.getAttestation();
+
+      expect(result).toEqual(getFakeAttestation());
+      expect(mockDstackClient.info).not.toHaveBeenCalled();
+      expect(mockDstackClient.getQuote).not.toHaveBeenCalled();
     });
   });
 

--- a/shade-agent-js/tests/unit/api.test.ts
+++ b/shade-agent-js/tests/unit/api.test.ts
@@ -81,7 +81,7 @@ describe("ShadeClient", () => {
   // Helper function to set up mocks
   function setupClientMocks(options?: {
     dstackClient?: ReturnType<typeof createMockDstackClient>;
-    derivedWithTEE?: boolean;
+    derivedWithRandom?: boolean;
     keysToAdd?: string[];
     wasChecked?: boolean;
   }) {
@@ -92,7 +92,7 @@ describe("ShadeClient", () => {
     vi.mocked(generateAgent).mockResolvedValue({
       accountId: testAccountId,
       agentPrivateKey: testPrivateKey,
-      derivedWithTEE: options?.derivedWithTEE ?? false,
+      derivedWithRandom: options?.derivedWithRandom ?? false,
     });
     vi.mocked(createAccountObject).mockReturnValue(mockAccount);
     vi.mocked(ensureKeysSetup).mockResolvedValue({
@@ -145,7 +145,7 @@ describe("ShadeClient", () => {
     it("should create ShadeClient with TEE client", async () => {
       setupClientMocks({
         dstackClient: mockDstackClient,
-        derivedWithTEE: true,
+        derivedWithRandom: true,
       });
       const config: ShadeConfig = {};
 
@@ -690,7 +690,7 @@ describe("ShadeClient", () => {
     it("should use TEE client if available", async () => {
       setupClientMocks({
         dstackClient: mockDstackClient,
-        derivedWithTEE: true,
+        derivedWithRandom: true,
       });
       const attestation = createMockContractAttestation({ quote: [4, 5, 6] });
       vi.mocked(internalGetAttestation).mockResolvedValue(attestation);

--- a/shade-agent-js/tests/unit/redaction.test.ts
+++ b/shade-agent-js/tests/unit/redaction.test.ts
@@ -18,7 +18,6 @@ import {
   removeKeysFromAccount,
   createAccountObject,
 } from "../../src/utils/near";
-import { generateAgent } from "../../src/utils/agent";
 import { internalGetAttestation } from "../../src/utils/tee";
 import {
   transformQuote,
@@ -125,17 +124,6 @@ describe("redaction: each wrapped function routes errors through toThrowable", (
       await expectThrows(() =>
         createAccountObject("agent.testnet", createMockProvider()),
       );
-      expect(errorsModule.toThrowable).toHaveBeenCalled();
-    });
-  });
-
-  describe("agent.ts", () => {
-    it("generateAgent (TEE path)", async () => {
-      const client = createMockDstackClient();
-      (client.getKey as ReturnType<typeof vi.fn>).mockRejectedValue(
-        new Error("TEE fail"),
-      );
-      await expectThrows(() => generateAgent(client, undefined));
       expect(errorsModule.toThrowable).toHaveBeenCalled();
     });
   });

--- a/shade-agent-js/tests/unit/tee.test.ts
+++ b/shade-agent-js/tests/unit/tee.test.ts
@@ -107,7 +107,7 @@ describe("tee utils", () => {
       expect(result).toEqual(getFakeAttestation());
     });
 
-    it("should return dummy attestation when keysDerivedWithTEE is false", async () => {
+    it("should return dummy attestation when keysDerivedWithRandom is false", async () => {
       const mockClient = createMockDstackClient();
       const result = await internalGetAttestation(
         mockClient,


### PR DESCRIPTION
We don't need the key entropy, JS random is sufficient 