### PR TITLE
feat(shade-attestation): Treat advisory IDs as informational

### DIFF
--- a/shade-attestation/src/attestation.rs
+++ b/shade-attestation/src/attestation.rs
@@ -14,7 +14,6 @@ use alloc::{
 };
 use borsh::{BorshDeserialize, BorshSerialize};
 use core::fmt;
-use dcap_qvl::verify::VerifiedReport;
 use derive_more::Constructor;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
@@ -39,6 +38,18 @@ pub struct DstackAttestation {
     pub tcb_info: TcbInfo,
 }
 
+/// Result of a successful [`DstackAttestation::verify`] call.
+#[derive(Clone, Debug)]
+pub struct AcceptedDstackAttestation {
+    pub measurements: FullMeasurements,
+    pub ppid: HexBytes<16>,
+    /// Informational advisory IDs (e.g. `INTEL-DOC-10000` post-ESU) surfaced by
+    /// Intel's PCS alongside an `UpToDate` TCB status. They are not a security
+    /// failure — `UpToDate` is the sole security gate; these advisories convey
+    /// platform lifecycle information.
+    pub advisory_ids: Vec<String>,
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, thiserror::Error)]
 pub enum VerificationError {
     #[error("could not parse embedded measurements: {0}")]
@@ -49,8 +60,6 @@ pub enum VerificationError {
     ReportNotTd10,
     #[error("TCB status `{0}` is not up to date")]
     TcbStatusNotUpToDate(String),
-    #[error("ouststanding advisories reported: {0}")]
-    NonEmptyAdvisoryIds(String),
     #[error("wrong {name} hash (found {found} expected {expected})")]
     WrongHash {
         name: &'static str,
@@ -152,14 +161,15 @@ impl DstackAttestation {
     ///   valid.
     /// - accepted_ppids: set of accepted PPIDs. PPID in the attestation must match one of the allowed PPIDs.
     ///
-    /// Returns the `FullMeasurements` that matched and the verified PPID if verification succeeds.
+    /// Returns the `FullMeasurements` that matched, the verified PPID
+    /// and informational advisory IDs if verification succeeds.
     pub fn verify(
         &self,
         expected_report_data: ReportData,
         timestamp_seconds: u64,
         accepted_measurements: &[FullMeasurements],
         accepted_ppids: &[HexBytes<16>],
-    ) -> Result<(FullMeasurements, HexBytes<16>), VerificationError> {
+    ) -> Result<AcceptedDstackAttestation, VerificationError> {
         let verification_result =
             dcap_qvl::verify::verify(&self.quote, &self.collateral, timestamp_seconds)
                 .map_err(|e| VerificationError::DcapVerification(e.to_string()))?;
@@ -170,7 +180,7 @@ impl DstackAttestation {
             .ok_or(VerificationError::ReportNotTd10)?;
 
         // Verify all attestation components
-        self.verify_tcb_status(&verification_result)?;
+        let advisory_ids = Self::verify_tcb_status(&verification_result)?;
         self.verify_report_data(&expected_report_data, report_data)?;
         let ppid = self.verify_ppid(verification_result.ppid, accepted_ppids)?;
 
@@ -179,7 +189,12 @@ impl DstackAttestation {
 
         let measurements =
             self.verify_any_measurements(report_data, &self.tcb_info, accepted_measurements)?;
-        Ok((measurements, ppid))
+
+        Ok(AcceptedDstackAttestation {
+            measurements,
+            ppid,
+            advisory_ids,
+        })
     }
 
     /// Replays RTMR3 from the event log by hashing all relevant events together and verifies all
@@ -247,29 +262,28 @@ impl DstackAttestation {
         compare_hashes("app_compose_payload", &app_compose_hash, &expected_payload)
     }
 
-    /// Verifies TCB status and security advisories.
+    /// Verifies the TCB status and returns any advisory IDs reported alongside it.
+    ///
+    /// The "UpToDate" TCB status indicates that the measured platform components (CPU
+    /// microcode, firmware, etc.) match the latest known good values published by Intel
+    /// and do not require any updates or mitigations — this is the sole security gate.
+    ///
+    /// Intel's PCS surfaces `advisory_ids` for two distinct purposes:
+    ///   1. `INTEL-SA-NNNNN`: real Security Advisories. Intel only attaches these to
+    ///      a non-UpToDate TCB status, so they are implicitly rejected by the status
+    ///      check below.
+    ///   2. `INTEL-DOC-NNNNN`: informational lifecycle markers (e.g. `INTEL-DOC-10000`
+    ///      after a product's Extended Servicing Updates date). These may appear with
+    ///      `UpToDate` and do not indicate a vulnerability; they are returned so the
+    ///      caller can log/expose them.
     fn verify_tcb_status(
-        &self,
-        verification_result: &VerifiedReport,
-    ) -> Result<(), VerificationError> {
-        // The "UpToDate" TCB status indicates that the measured platform components (CPU
-        // microcode, firmware, etc.) match the latest known good values published by Intel
-        // and do not require any updates or mitigations.
-        let status_is_up_to_date = verification_result.status == EXPECTED_QUOTE_STATUS;
-
-        // Advisory IDs indicate known security vulnerabilities or issues with the TEE.
-        // For a quote to be considered secure, there should be no outstanding advisories.
-        let no_security_advisories = verification_result.advisory_ids.is_empty();
-
-        status_is_up_to_date.or_err(|| {
+        verification_result: &dcap_qvl::verify::VerifiedReport,
+    ) -> Result<Vec<String>, VerificationError> {
+        (verification_result.status == EXPECTED_QUOTE_STATUS).or_err(|| {
             VerificationError::TcbStatusNotUpToDate(verification_result.status.clone())
         })?;
 
-        no_security_advisories.or_err(|| {
-            VerificationError::NonEmptyAdvisoryIds(verification_result.advisory_ids.join(", "))
-        })?;
-
-        Ok(())
+        Ok(verification_result.advisory_ids.clone())
     }
 
     /// Verifies report data matches expected values.
@@ -590,37 +604,35 @@ mod tests {
 
     // -------- verify_tcb_status --------
 
-    // "UpToDate" + no advisories passes.
+    // "UpToDate" + no advisories passes and returns no advisory IDs.
     #[test]
     fn verify_tcb_status_accepts_up_to_date_no_advisories() {
-        let attestation = create_mock_dstack_attestation();
         let report = verified_report("UpToDate", Vec::new());
-        assert_eq!(attestation.verify_tcb_status(&report), Ok(()));
+        assert_eq!(
+            DstackAttestation::verify_tcb_status(&report),
+            Ok(Vec::new())
+        );
     }
 
     // Any non-"UpToDate" status fails.
     #[test]
     fn verify_tcb_status_rejects_out_of_date_status() {
-        let attestation = create_mock_dstack_attestation();
         let report = verified_report("OutOfDate", Vec::new());
         assert_eq!(
-            attestation.verify_tcb_status(&report),
+            DstackAttestation::verify_tcb_status(&report),
             Err(VerificationError::TcbStatusNotUpToDate(
                 "OutOfDate".to_string()
             ))
         );
     }
 
-    // Outstanding advisories fail even when status is "UpToDate".
+    // Informational advisories are returned alongside an "UpToDate" status.
     #[test]
-    fn verify_tcb_status_rejects_non_empty_advisories() {
-        let attestation = create_mock_dstack_attestation();
-        let report = verified_report("UpToDate", vec!["INTEL-SA-00001".to_string()]);
+    fn verify_tcb_status_returns_informational_advisories() {
+        let report = verified_report("UpToDate", vec!["INTEL-DOC-10000".to_string()]);
         assert_eq!(
-            attestation.verify_tcb_status(&report),
-            Err(VerificationError::NonEmptyAdvisoryIds(
-                "INTEL-SA-00001".to_string()
-            ))
+            DstackAttestation::verify_tcb_status(&report),
+            Ok(vec!["INTEL-DOC-10000".to_string()])
         );
     }
 

--- a/shade-attestation/src/measurements.rs
+++ b/shade-attestation/src/measurements.rs
@@ -210,8 +210,14 @@ mod tests {
         assert_eq!(back.rtmrs.rtmr0, original.rtmrs.rtmr0);
         assert_eq!(back.rtmrs.rtmr1, original.rtmrs.rtmr1);
         assert_eq!(back.rtmrs.rtmr2, original.rtmrs.rtmr2);
-        assert_eq!(back.key_provider_event_digest, original.key_provider_event_digest);
-        assert_eq!(back.app_compose_hash_payload, original.app_compose_hash_payload);
+        assert_eq!(
+            back.key_provider_event_digest,
+            original.key_provider_event_digest
+        );
+        assert_eq!(
+            back.app_compose_hash_payload,
+            original.app_compose_hash_payload
+        );
     }
 
     // Borsh serialize → deserialize preserves all fields.
@@ -224,8 +230,14 @@ mod tests {
         assert_eq!(back.rtmrs.rtmr0, original.rtmrs.rtmr0);
         assert_eq!(back.rtmrs.rtmr1, original.rtmrs.rtmr1);
         assert_eq!(back.rtmrs.rtmr2, original.rtmrs.rtmr2);
-        assert_eq!(back.key_provider_event_digest, original.key_provider_event_digest);
-        assert_eq!(back.app_compose_hash_payload, original.app_compose_hash_payload);
+        assert_eq!(
+            back.key_provider_event_digest,
+            original.key_provider_event_digest
+        );
+        assert_eq!(
+            back.app_compose_hash_payload,
+            original.app_compose_hash_payload
+        );
     }
 
     // create_mock_full_measurements_hex returns the documented zero-filled shape.

--- a/shade-contract-template/Cargo.lock
+++ b/shade-contract-template/Cargo.lock
@@ -3859,7 +3859,7 @@ dependencies = [
 
 [[package]]
 name = "shade-attestation"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "borsh",
  "dcap-qvl",

--- a/shade-contract-template/src/internal/attestation.rs
+++ b/shade-contract-template/src/internal/attestation.rs
@@ -4,8 +4,8 @@ impl Contract {
     pub(crate) fn verify_attestation(
         &self,
         attestation: DstackAttestation,
-    ) -> (FullMeasurementsHex, Ppid) {
-        let result: (FullMeasurementsHex, Ppid) = match self.requires_tee {
+    ) -> (FullMeasurementsHex, Ppid, Vec<String>) {
+        let result: (FullMeasurementsHex, Ppid, Vec<String>) = match self.requires_tee {
             true => {
                 // Verify account_ID is an implicit account ID
                 let account_id_str = env::predecessor_account_id().to_string();
@@ -42,9 +42,11 @@ impl Contract {
                     &expected_measurements,
                     &approved_ppids,
                 ) {
-                    Ok((verified_measurements, verified_ppid)) => {
-                        (verified_measurements.into(), verified_ppid)
-                    }
+                    Ok(AcceptedDstackAttestation {
+                        measurements,
+                        ppid,
+                        advisory_ids,
+                    }) => (measurements.into(), ppid, advisory_ids),
                     Err(e) => {
                         panic!("Attestation verification failed: {}", e);
                     }
@@ -66,7 +68,7 @@ impl Contract {
                     self.approved_ppids.contains(&Ppid::default()),
                     "Default PPID must be approved for local mode"
                 );
-                (default_measurements, Ppid::default())
+                (default_measurements, Ppid::default(), Vec::new())
             }
         };
         result

--- a/shade-contract-template/src/internal/events.rs
+++ b/shade-contract-template/src/internal/events.rs
@@ -3,6 +3,22 @@ use crate::*;
 const EVENT_STANDARD: &str = "shade-contract-template";
 const EVENT_STANDARD_VERSION: &str = "1.0.0";
 
+/// Maximum number of advisory IDs surfaced in an event; the full count is reported
+/// separately via `number_of_advisory_ids` to keep event/log size bounded.
+pub const MAX_ADVISORY_IDS: usize = 8;
+
+/// Caps advisory IDs to at most [`MAX_ADVISORY_IDS`] for [`Event::AgentRegistered`],
+/// returning the capped list together with the true total.
+pub fn summarize_advisory_ids(advisory_ids: &[String]) -> (Vec<String>, u16) {
+    let number_of_advisory_ids = u16::try_from(advisory_ids.len()).unwrap_or(u16::MAX);
+    let advisory_ids_max_8 = advisory_ids
+        .iter()
+        .take(MAX_ADVISORY_IDS)
+        .cloned()
+        .collect();
+    (advisory_ids_max_8, number_of_advisory_ids)
+}
+
 #[derive(Serialize, Debug, Clone)]
 #[serde(crate = "near_sdk::serde")]
 #[serde(tag = "event", content = "data")]
@@ -13,6 +29,8 @@ pub enum Event<'a> {
         account_id: &'a AccountId,
         measurements: &'a FullMeasurementsHex,
         ppid: &'a Ppid,
+        advisory_ids_max_8: Vec<String>,
+        number_of_advisory_ids: u16,
         current_time_ms: U64,
         valid_until_ms: U64,
         // Cannot log attestation, it's too large

--- a/shade-contract-template/src/internal/events.rs
+++ b/shade-contract-template/src/internal/events.rs
@@ -11,12 +11,12 @@ pub const MAX_ADVISORY_IDS: usize = 8;
 /// returning the capped list together with the true total.
 pub fn summarize_advisory_ids(advisory_ids: &[String]) -> (Vec<String>, u16) {
     let number_of_advisory_ids = u16::try_from(advisory_ids.len()).unwrap_or(u16::MAX);
-    let advisory_ids_max_8 = advisory_ids
+    let advisory_ids_truncated = advisory_ids
         .iter()
         .take(MAX_ADVISORY_IDS)
         .cloned()
         .collect();
-    (advisory_ids_max_8, number_of_advisory_ids)
+    (advisory_ids_truncated, number_of_advisory_ids)
 }
 
 #[derive(Serialize, Debug, Clone)]
@@ -29,7 +29,7 @@ pub enum Event<'a> {
         account_id: &'a AccountId,
         measurements: &'a FullMeasurementsHex,
         ppid: &'a Ppid,
-        advisory_ids_max_8: Vec<String>,
+        advisory_ids_truncated: Vec<String>,
         number_of_advisory_ids: u16,
         current_time_ms: U64,
         valid_until_ms: U64,

--- a/shade-contract-template/src/internal/unit_tests.rs
+++ b/shade-contract-template/src/internal/unit_tests.rs
@@ -1107,3 +1107,48 @@ fn test_get_agents_expiration_fields() {
     );
     assert!(matches!(agent2_info.validity, AgentValidity::Valid));
 }
+
+// -------- summarize_advisory_ids (AgentRegistered event payload) --------
+
+use super::events::{MAX_ADVISORY_IDS, summarize_advisory_ids};
+
+// Builds `n` distinct advisory IDs in a stable order.
+fn advisory_ids(n: usize) -> Vec<String> {
+    (0..n).map(|i| format!("INTEL-DOC-{i}")).collect()
+}
+
+// No advisories: empty list and a zero count.
+#[test]
+fn summarize_advisory_ids_empty() {
+    let (shown, total) = summarize_advisory_ids(&[]);
+    assert!(shown.is_empty());
+    assert_eq!(total, 0);
+}
+
+// Fewer than the cap: every ID is returned, in order, with the exact count.
+#[test]
+fn summarize_advisory_ids_below_cap() {
+    let ids = advisory_ids(3);
+    let (shown, total) = summarize_advisory_ids(&ids);
+    assert_eq!(shown, ids);
+    assert_eq!(total, 3);
+}
+
+// Exactly at the cap: every ID is returned and none are dropped.
+#[test]
+fn summarize_advisory_ids_at_cap() {
+    let ids = advisory_ids(MAX_ADVISORY_IDS);
+    let (shown, total) = summarize_advisory_ids(&ids);
+    assert_eq!(shown, ids);
+    assert_eq!(total as usize, MAX_ADVISORY_IDS);
+}
+
+// More than the cap: the shown list is truncated to the first `MAX_ADVISORY_IDS`,
+// but the reported total still reflects the true number of advisories.
+#[test]
+fn summarize_advisory_ids_above_cap_truncates_but_counts_all() {
+    let ids = advisory_ids(MAX_ADVISORY_IDS + 4);
+    let (shown, total) = summarize_advisory_ids(&ids);
+    assert_eq!(shown.as_slice(), &ids[..MAX_ADVISORY_IDS]);
+    assert_eq!(total as usize, MAX_ADVISORY_IDS + 4);
+}

--- a/shade-contract-template/src/lib.rs
+++ b/shade-contract-template/src/lib.rs
@@ -105,14 +105,14 @@ impl Contract {
         let (measurements, ppid, advisory_ids) = self.verify_attestation(attestation.clone());
 
         let valid_until_ms = block_timestamp_ms() + self.attestation_expiration_time_ms;
-        let (advisory_ids_max_8, number_of_advisory_ids) =
+        let (advisory_ids_truncated, number_of_advisory_ids) =
             internal::events::summarize_advisory_ids(&advisory_ids);
 
         Event::AgentRegistered {
             account_id: &predecessor,
             measurements: &measurements,
             ppid: &ppid,
-            advisory_ids_max_8,
+            advisory_ids_truncated,
             number_of_advisory_ids,
             current_time_ms: U64::from(block_timestamp_ms()),
             valid_until_ms: U64::from(valid_until_ms),

--- a/shade-contract-template/src/lib.rs
+++ b/shade-contract-template/src/lib.rs
@@ -10,7 +10,7 @@ use near_sdk::{
     store::{IterableMap, IterableSet},
 };
 use shade_attestation::{
-    attestation::DstackAttestation,
+    attestation::{AcceptedDstackAttestation, DstackAttestation},
     measurements::{FullMeasurements, FullMeasurementsHex, create_mock_full_measurements_hex},
     report_data::ReportData,
     tcb_info::HexBytes,
@@ -102,14 +102,18 @@ impl Contract {
         }
 
         // Verify the attestation and get the measurements and PPID for the agent
-        let (measurements, ppid) = self.verify_attestation(attestation.clone());
+        let (measurements, ppid, advisory_ids) = self.verify_attestation(attestation.clone());
 
         let valid_until_ms = block_timestamp_ms() + self.attestation_expiration_time_ms;
+        let (advisory_ids_max_8, number_of_advisory_ids) =
+            internal::events::summarize_advisory_ids(&advisory_ids);
 
         Event::AgentRegistered {
             account_id: &predecessor,
             measurements: &measurements,
             ppid: &ppid,
+            advisory_ids_max_8,
+            number_of_advisory_ids,
             current_time_ms: U64::from(block_timestamp_ms()),
             valid_until_ms: U64::from(valid_until_ms),
         }

--- a/shade-contract-template/tests/attestation_tests.rs
+++ b/shade-contract-template/tests/attestation_tests.rs
@@ -956,8 +956,8 @@ async fn test_attestation_expiration() -> Result<(), Box<dyn std::error::Error +
 
 /// First-time `register_agent` must attach storage stake; zero deposit fails until then.
 #[tokio::test]
-async fn test_register_agent_new_agent_requires_storage_deposit_integration(
-) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+async fn test_register_agent_new_agent_requires_storage_deposit_integration()
+-> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let sandbox = near_sandbox::Sandbox::start_sandbox().await?;
     let network_config = create_network_config(&sandbox);
     let (genesis_account_id, genesis_signer) = setup_genesis_account().await;
@@ -1028,7 +1028,9 @@ async fn test_register_agent_new_agent_requires_storage_deposit_integration(
         &network_config,
     )
     .await?;
-    let agent = agent_info.data.expect("agent should be registered after first success");
+    let agent = agent_info
+        .data
+        .expect("agent should be registered after first success");
     assert!(
         matches!(agent.validity, AgentValidity::Valid),
         "Agent should be valid after first registration"
@@ -1038,8 +1040,8 @@ async fn test_register_agent_new_agent_requires_storage_deposit_integration(
 }
 
 #[tokio::test]
-async fn test_register_agent_reregister_without_storage_deposit_integration(
-) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+async fn test_register_agent_reregister_without_storage_deposit_integration()
+-> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let sandbox = near_sandbox::Sandbox::start_sandbox().await?;
     let network_config = create_network_config(&sandbox);
     let (genesis_account_id, genesis_signer) = setup_genesis_account().await;


### PR DESCRIPTION
Follows https://github.com/near/mpc/pull/3296