### PR TITLE
perf(contract): drop unnecessary attestation clone in register_agent

### DIFF
--- a/shade-contract-template/src/lib.rs
+++ b/shade-contract-template/src/lib.rs
@@ -102,7 +102,7 @@ impl Contract {
         }
 
         // Verify the attestation and get the measurements and PPID for the agent
-        let (measurements, ppid, advisory_ids) = self.verify_attestation(attestation.clone());
+        let (measurements, ppid, advisory_ids) = self.verify_attestation(attestation);
 
         let valid_until_ms = block_timestamp_ms() + self.attestation_expiration_time_ms;
         let (advisory_ids_truncated, number_of_advisory_ids) =


### PR DESCRIPTION
`register_agent` owns the `attestation` argument and never uses it after the `verify_attestation` call; `verify_attestation` also takes it **by value**. So we can move it in rather than clone.

```rust
-let (measurements, ppid, advisory_ids) = self.verify_attestation(attestation.clone());
+let (measurements, ppid, advisory_ids) = self.verify_attestation(attestation);
```

The clone deep-copied the quote / collateral / tcb_info byte buffers on every registration for no reason. Verified with the contract builder.