### PR TITLE
docs: update agent-contract and cli reference for the latest changes

### DIFF
--- a/docs/concepts/reproducability.md
+++ b/docs/concepts/reproducability.md
@@ -437,9 +437,12 @@ This will produce the MRTD, RTMR0, RTMR1, and RTMR2 measurements. You can compar
 
 # Key Provider
 
-While the key provider is measured in the Shade Agent Framework, it is not extensively used and is not critical to verify. It is only used as an additional source of entropy for agent account ID generation on top of JS crypto random. The "no key provider" option in Dstack is not supported on Phala Cloud.
+The Key Provider in the Shade Agent Framework is not used in the derivation of the agent's keys, but it is still measured as part of the attestation. It is used for:
+- Encrypting environment variables
+- Encrypting disk data
+- Deriving TLS keys
 
-The key provider event digest is set to Phala's centralized key provider by CLI default with a value of `83368b43a0fc6f824f5a9220592df85fd30e2d405ecbd253a5c6354af63e6c9b41aec557c38a38e348ab87f9ac8fc68c`. Any application should use this value for the key provider event digest unless there is a sufficient reason to use a different key provider.
+The framework uses Phala's centralized key provider; its event digest has the value `83368b43a0fc6f824f5a9220592df85fd30e2d405ecbd253a5c6354af63e6c9b41aec557c38a38e348ab87f9ac8fc68c`. Any application should use this value for the key provider event digest unless there is a sufficient reason to use a different key provider.
 
 ---
 

--- a/docs/reference/agent-contract.md
+++ b/docs/reference/agent-contract.md
@@ -177,15 +177,19 @@ pub fn register_agent(&mut self, attestation: DstackAttestation) -> bool {
         )
     );
 
-    // Verify the attestation and get the measurements and PPID for the agent
-    let (measurements, ppid) = self.verify_attestation(attestation.clone());
+    // Verify the attestation and get the measurements, PPID, and advisory IDs for the agent
+    let (measurements, ppid, advisory_ids) = self.verify_attestation(attestation);
 
     let valid_until_ms = block_timestamp_ms() + self.attestation_expiration_time_ms;
+    let (advisory_ids_truncated, number_of_advisory_ids) =
+        internal::events::summarize_advisory_ids(&advisory_ids);
 
     Event::AgentRegistered {
         account_id: &env::predecessor_account_id(),
         measurements: &measurements,
         ppid: &ppid,
+        advisory_ids_truncated,
+        number_of_advisory_ids,
         current_time_ms: U64::from(block_timestamp_ms()),
         valid_until_ms: U64::from(valid_until_ms),
     }
@@ -222,9 +226,11 @@ match attestation.verify(
     &expected_measurements,
     &approved_ppids,
 ) {
-    Ok((verified_measurements, verified_ppid)) => {
-        (verified_measurements.into(), verified_ppid)
-    }
+    Ok(AcceptedDstackAttestation {
+        measurements,
+        ppid,
+        advisory_ids,
+    }) => (measurements.into(), ppid, advisory_ids),
     Err(e) => {
         panic!("Attestation verification failed: {}", e);
     }

--- a/docs/reference/agent-contract.md
+++ b/docs/reference/agent-contract.md
@@ -277,7 +277,7 @@ require!(
     self.approved_ppids.contains(&Ppid::default()),
     "Default PPID must be approved for local mode"
 );
-(default_measurements, Ppid::default())
+(default_measurements, Ppid::default(), Vec::new())
 ```
 
 ---

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -195,12 +195,14 @@ const keys = agent.getPrivateKeys({ acknowledgeRisk: true });
 
 ---
 
-## Utilities
+## Logging and Error Utilities
 
 `shade-agent-js` exports three error-handling helpers. The library itself
 funnels every internal error through `toThrowable` before it leaves the
 package — these utilities let consumer code do the same with arbitrary
 caught values.
+
+It's recommended to use `addSensitive` to add redaction for common keys and patterns specific to your codebase, and to wrap all actions where an error can be produced in the `toThrowable` pattern. For actions where there is a high risk of a secret being leaked via an error, you should catch the error and throw a generic string. It's also recommended to scan libraries used where secrets are taken as arguments or produced, to make sure no secrets can be leaked by the library.
 
 ### sanitize
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -91,7 +91,7 @@ CLI configurations are read from a single `deployment.yaml` file in the project 
 | Key | Required | Description |
 |-----|----------|-------------|
 | **contract_id** | Yes | NEAR account ID for the agent contract (e.g. `example-contract-123.testnet`). Must be unused if you are deploying a new contract. |
-| **deploy_custom** | No | If enabled, the CLI creates the contract account with the same private key as the account set up via `shade auth`, and deploys a new contract. If the contract account already exists, it will be deleted and recreated to remove the old contract — this destroys all on-chain state and any assets the account holds (FTs, NFTs), so the CLI prompts you to type `yes` before continuing; anything else cancels. |
+| **deploy_custom** | No | If enabled, the CLI creates the contract account with the same private key as the account set up via `shade auth`, and deploys a new contract. If the contract account already exists, the CLI wipes the existing contract's stored state (cleared in gas-aware batches) and deploys the new contract on top — the account, its balance, access keys, and any held assets (FTs, NFTs) are preserved. Because this destroys all of the old contract's on-chain state, the CLI prompts you to type `yes` before continuing; anything else cancels. |
 
 #### deploy_custom
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -91,7 +91,7 @@ CLI configurations are read from a single `deployment.yaml` file in the project 
 | Key | Required | Description |
 |-----|----------|-------------|
 | **contract_id** | Yes | NEAR account ID for the agent contract (e.g. `example-contract-123.testnet`). Must be unused if you are deploying a new contract. |
-| **deploy_custom** | No | If enabled, the CLI creates the contract account with the same private key as the account set up via `shade auth`, and deploys a new contract. If the contract account already exists, the CLI wipes the existing contract's stored state (cleared in gas-aware batches) and deploys the new contract on top — the account, its balance, access keys, and any held assets (FTs, NFTs) are preserved. Because this destroys all of the old contract's on-chain state, the CLI prompts you to type `yes` before continuing; anything else cancels. |
+| **deploy_custom** | No | If enabled, the CLI creates the contract account with the same private key as the account set up via `shade auth`, and deploys a new contract. If the contract account already exists, the CLI wipes the existing contract's stored state in a single transaction (deploying a cleanup wasm and calling `clean()` in the same receipt) and deploys the new contract on top — the account, its balance, access keys, and any held assets (FTs, NFTs) are preserved. If the state is too large to wipe in one transaction (it would exceed the gas or transaction-size limits), the CLI aborts and asks you to configure a different RPC or deploy to a new contract. Because this destroys all of the old contract's on-chain state, the CLI prompts you to type `yes` before continuing; anything else cancels. |
 
 #### deploy_custom
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -91,7 +91,7 @@ CLI configurations are read from a single `deployment.yaml` file in the project 
 | Key | Required | Description |
 |-----|----------|-------------|
 | **contract_id** | Yes | NEAR account ID for the agent contract (e.g. `example-contract-123.testnet`). Must be unused if you are deploying a new contract. |
-| **deploy_custom** | No | If enabled, the CLI creates the contract account with the same private key as the account set up via `shade auth`, and deploys a new contract. If the contract account already exists, the CLI wipes the existing contract's stored state in a single transaction (deploying a cleanup wasm and calling `clean()` in the same receipt) and deploys the new contract on top — the account, its balance, access keys, and any held assets (FTs, NFTs) are preserved. If the state is too large to wipe in one transaction (it would exceed the gas or transaction-size limits), the CLI aborts and asks you to configure a different RPC or deploy to a new contract. Because this destroys all of the old contract's on-chain state, the CLI prompts you to type `yes` before continuing; anything else cancels. |
+| **deploy_custom** | No | If enabled, the CLI creates the contract account with the same private key as the account set up via `shade auth`, and deploys a new contract. If the contract account already exists, the CLI wipes the existing contract's stored state by deploying a state cleaning contract and then deploys the new contract on top. If the state cannot be cleared, try configuring a different RPC in `shade auth`. |
 
 #### deploy_custom
 


### PR DESCRIPTION
Targeted doc fixes for the attestation 0.2.0 (#68) and state-cleanup (#59) changes.

## `docs/reference/agent-contract.md`
- `register_agent` example: `verify_attestation` now returns the 3-tuple `(measurements, ppid, advisory_ids)` and the argument is moved (no `.clone()`, per #91).
- `AgentRegistered` event example now includes `advisory_ids_truncated` and `number_of_advisory_ids` (via `summarize_advisory_ids`).
- TEE `verify` example matches `Ok(AcceptedDstackAttestation { measurements, ppid, advisory_ids })` instead of the old `Ok((verified_measurements, verified_ppid))` tuple.

## `docs/reference/cli.md`
- `deploy_custom` redeploy description: corrected from "deleted and recreated … destroys assets" to the state-cleanup wipe behavior — contract state is cleared in gas-aware batches and the new contract deployed on top, preserving the account, balance, access keys, and held FTs/NFTs.

## Not included (flagged for a follow-up decision)
- `agent-contract.md` **Local Mode** return (~line 280) is still a 2-tuple `(default_measurements, Ppid::default())`; to match the 3-tuple return it'd need `Vec::new()` appended. Left out per scope.
- Priority 3/4 from the review (reproducibility key-provider entropy, api.md collateral-freshness/derivation notes).