### PR TITLE
ci: add comment-triggered Claude PR review (@claude)

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,36 @@
+name: Claude PR Assistant
+
+# Comment-triggered: mention @claude in a PR/issue comment or an inline PR
+# review comment, and Claude runs with whatever you wrote after @claude as the
+# instruction (e.g. "@claude review this for SQL injection risks").
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+
+jobs:
+  claude:
+    # Only run when the comment actually mentions @claude — without this guard
+    # every comment would start a run and draw down subscription usage.
+    if: contains(github.event.comment.body, '@claude')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read          # read the code being reviewed
+      pull-requests: write     # post review comments / replies on PRs
+      issues: write            # respond on issues
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0       # full history so Claude can diff against the base
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          # Authenticates with a Claude subscription (Max) via an OAuth token,
+          # not a metered API key. Generate with `claude setup-token` and store
+          # the value as the CLAUDE_CODE_OAUTH_TOKEN repo secret.
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+
+          # The action defaults to Sonnet. For sharper (but slower / more
+          # token-hungry) reviews, switch to Opus by uncommenting:
+          # claude_args: "--model claude-opus-4-8"


### PR DESCRIPTION
## What

Adds `.github/workflows/claude.yml` — a **comment-triggered** review workflow. Mention `@claude` in a PR/issue comment or an inline PR review comment and `anthropics/claude-code-action@v1` runs with whatever you wrote after `@claude` as the instruction (e.g. `@claude review this for SQL injection risks`).

## Auth: subscription OAuth token (no API key)

Uses `claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}`, which draws on a Claude subscription's usage allowance rather than metered API billing.

## ⚠️ Required before this works (maintainer action — can't be done in this PR)

1. **Generate the token** locally: `claude setup-token` (needs an active Claude subscription).
2. **Store it as a repo secret** named `CLAUDE_CODE_OAUTH_TOKEN` (Settings → Secrets and variables → Actions, or `gh secret set CLAUDE_CODE_OAUTH_TOKEN -R NearDeFi/shade-agent-framework`).
3. **Install the Claude GitHub App** on this repo (`/install-github-app` in Claude Code, or https://github.com/apps/claude).

Until the secret exists, the action will fail to authenticate if triggered. Comment events only fire from the **default branch** copy of the workflow, so this must merge to `main` to take effect.

## Notes

- Defaults to Sonnet; a commented `claude_args: "--model claude-opus-4-8"` line is included to opt into Opus.
- Least-privilege-ish permissions: `contents: read`, `pull-requests: write`, `issues: write`. Bump `contents` to `write` only if you want Claude to push code fixes.
- **Subscription quota:** every run is attributed to the token-owner's account and counts against their Max limits — a shared ceiling if you run many automated reviews.
- **Fork safety:** fork PRs don't get repo secrets by default, so external contributors can't trigger this and burn your usage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)