### PR TITLE
ci: grant id-token write to the claude-review workflow

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -22,6 +22,7 @@ jobs:
       contents: read
       pull-requests: write
       issues: write
+      id-token: write
     env:
       PR_NUMBER: ${{ github.event.issue.number }}
     steps:


### PR DESCRIPTION
## Problem

`/claude-review` runs but **fails on every run** — it never posts a review. The most recent run on PR #95 ([run 27677681190](https://github.com/NearDeFi/shade-agent-framework/actions/runs/27677681190)) completed with `failure` at the *Run Claude Code review* step:

```
Could not fetch an OIDC token. Did you remember to add `id-token: write` to your workflow permissions?
```

`anthropics/claude-code-action@v1` authenticates via a GitHub OIDC token, which requires `id-token: write` in the job's `permissions`. The job only had `contents: read`, `pull-requests: write`, `issues: write`, so the action aborted before it could review or comment.

## Change

One line — add `id-token: write` to the `claude` job's `permissions` block in `.github/workflows/claude-review.yml`.

## Note

Like any `issue_comment`-triggered workflow, this only takes effect once it's on the **default branch** (`main`). After merge, a fresh `/claude-review` comment is needed to re-trigger — the previously failed run does not retry on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)