### PR TITLE
chore: request Copilot review explicitly in the PR commands

### DIFF
--- a/.claude/commands/fix-issue.md
+++ b/.claude/commands/fix-issue.md
@@ -127,6 +127,14 @@ Read `.claude/commands/utils/check-and-fix-ci.md` and follow it for PR #{pr-numb
    gh pr comment {pr-number} --repo {REPO} --body "/claude-review"
    ```
 
-   This fires only if `claude-review.yml` is on the repo's default branch and the authenticated `gh` user is the configured trigger user — if the workflow doesn't start, say so in the recap rather than re-commenting. Copilot review is **not** comment-triggered: if the repo has the Copilot review ruleset, opening the PR already requested Copilot automatically — do not comment for it.
+   This fires only if `claude-review.yml` is on the repo's default branch and the authenticated `gh` user is the configured trigger user — if the workflow doesn't start, say so in the recap rather than re-commenting.
 
-2. Report back in chat: the PR URL, the CI outcome, whether the Claude review comment was posted, whether Copilot was auto-requested (if the ruleset is set up), and a short recap of the change, tests, and open questions. Remind the user: once the reviews land, continue with `/resolve-pr-reviews {pr-number}`.
+2. Request the Copilot review. Copilot is **not** comment-triggered and is **not** auto-requested (there is no Copilot review ruleset), so request it explicitly via the API — the reviewer slug is `copilot-pull-request-reviewer[bot]`, and it reviews the current head:
+
+   ```
+   gh api --method POST repos/{REPO}/pulls/{pr-number}/requested_reviewers -f "reviewers[]=copilot-pull-request-reviewer[bot]"
+   ```
+
+   This needs the repo/author to have Copilot code-review access and available premium-request quota; if the request errors or Copilot never posts, note it in the recap rather than retrying.
+
+3. Report back in chat: the PR URL, the CI outcome, whether the Claude review comment was posted, whether the Copilot review was requested, and a short recap of the change, tests, and open questions. Remind the user: once the reviews land, continue with `/resolve-pr-reviews {pr-number}`.

--- a/.claude/commands/resolve-pr-reviews.md
+++ b/.claude/commands/resolve-pr-reviews.md
@@ -89,7 +89,7 @@ Draft: {yes|no}
 
 **Decide the mode:**
 
-1. **Claude or Copilot review missing or stale** → STOP. Tell the user which reviewer is missing and how to trigger it: Claude — comment `/claude-review` on the PR; Copilot — it reviews automatically on PR open and on each push via the repo's ruleset, so push a commit (or re-request it from the PR's Reviewers panel) if its review is missing or stale. Then re-run this command. Do not proceed.
+1. **Claude or Copilot review missing or stale** → STOP. Tell the user which reviewer is missing and how to trigger it: Claude — comment `/claude-review` on the PR; Copilot — it is **not** auto-requested, so re-request it explicitly with `gh api --method POST repos/{REPO}/pulls/{number}/requested_reviewers -f "reviewers[]=copilot-pull-request-reviewer[bot]"` (or the ↻ next to Copilot in the PR's Reviewers panel). Then re-run this command. Do not proceed.
 2. **Unresolved review comments exist** → Phase 2 (address them).
 3. **CI failing, no unresolved comments** → Phase 6 (jump to CI fix).
 4. **Both reviewed + CI passing + nothing unresolved** (no comments needing action, or all already resolved) → Phase 7 (clean path).
@@ -178,10 +178,11 @@ Read `.claude/commands/utils/check-and-fix-ci.md` and follow it for PR #{number}
 
 Two paths with different end states — report each honestly. Do not print a success card claiming the AI reviewers are satisfied unless their reviews actually cover the current head commit.
 
-**If this run pushed any commits** (review fixes from Phase 5 and/or CI fixes from Phase 6): the fixes are new code the reviewers have not seen — their earlier reviews are now stale, and whether they are happy with the result is unknown. The push already triggered Copilot's re-review (its ruleset reviews new pushes), so only Claude needs a comment:
+**If this run pushed any commits** (review fixes from Phase 5 and/or CI fixes from Phase 6): the fixes are new code the reviewers have not seen — their earlier reviews are now stale, and whether they are happy with the result is unknown. Both reviewers must be explicitly re-requested against the new head — Claude via a comment, Copilot via the API (it reviews the current head; needs Copilot access + premium-request quota):
 
 ```
 gh pr comment {number} --repo {REPO} --body "/claude-review"
+gh api --method POST repos/{REPO}/pulls/{number}/requested_reviewers -f "reviewers[]=copilot-pull-request-reviewer[bot]"
 ```
 
 Then report:
@@ -192,7 +193,7 @@ CI: ✅ PASS (on the new head)
 Findings fixed: {N}    Comments addressed: {N}    Commits added: {N}
 ```
 
-In prose, list which comments were addressed and what was pushed, note that Claude was re-requested and Copilot re-reviews the push automatically, and remind the user to re-run `/resolve-pr-reviews` after the new reviews land. Do **NOT** post "Reviews passed!" on this path.
+In prose, list which comments were addressed and what was pushed, note that both Claude and Copilot were re-requested against the new head, and remind the user to re-run `/resolve-pr-reviews` after the new reviews land. Do **NOT** post "Reviews passed!" on this path.
 
 **If this run started clean** (mode 4 — both reviewed the current head, CI passing, nothing to resolve, no commits pushed): post exactly one comment:
 


### PR DESCRIPTION
## What & why

The **"Copilot review" branch ruleset** (which auto-requested Copilot on PR open and re-reviewed each push to PRs into `main`) was **deleted** — it proved unreliable (it silently didn't re-review a push on #95) and we'd rather drive Copilot deterministically from the workflow commands.

This updates the two PR commands to request Copilot **explicitly** via the API instead of assuming the ruleset handles it.

## Changes

- **`.claude/commands/fix-issue.md`** (Step 9): after opening the PR, request Copilot via `gh api ... requested_reviewers -f "reviewers[]=copilot-pull-request-reviewer[bot]"` (was: "opening the PR already requested Copilot automatically").
- **`.claude/commands/resolve-pr-reviews.md`**:
  - Phase 1 (missing/stale reviewer guidance): re-request Copilot via the API (or the ↻ in the Reviewers panel) instead of "push a commit / it reviews on push".
  - Phase 7 (pushed-commits path): explicitly re-request **both** Claude (comment) and Copilot (API) against the new head, and the prose note reflects that.

Both note the prerequisites (Copilot code-review access + premium-request quota) and to surface failures in the recap rather than retrying.

## Recovery note

If the ruleset is ever wanted back, it was: target `branch`, condition `refs/heads/main`, rule `copilot_code_review` with `review_on_push: true`, `review_draft_pull_requests: false`, enforcement `active`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)