### PR TITLE
chore: keep PR description current in resolve-pr-reviews

### DIFF
--- a/.claude/commands/resolve-pr-reviews.md
+++ b/.claude/commands/resolve-pr-reviews.md
@@ -163,6 +163,16 @@ git push origin {headRefName}
 
 **Reply to addressed review comments on GitHub.** For each comment that was fixed, reply with the commit SHA and a brief description of what was done. For false positives, reply explaining why no change was needed.
 
+**Update the PR description to match the new head.** If the fixes changed what the PR does, the files it touches, the tests it adds, or its release impact, edit the PR body so it stays accurate to the current head. Fetch it, amend the relevant sections, and set it back (never blind-overwrite):
+
+```bash
+gh pr view {number} --repo {REPO} --json body --jq .body > /tmp/pr-{number}-body.md
+# edit the What-changed / Files-changed / Tests sections (and the release-impact line) in /tmp/pr-{number}-body.md
+gh pr edit {number} --repo {REPO} --body-file /tmp/pr-{number}-body.md
+```
+
+Keep the description a current *summary*, not a per-commit changelog — the commit history and the review-thread replies already record each fix. Per the repo's versioning convention (root `CLAUDE.md`), make sure the release-impact line still names the correct package(s) and major/minor/patch level for the change as it now stands. If nothing material changed (e.g. a pure comment/doc tweak), leave the body as-is.
+
 ---
 
 ## Phase 6: CI Monitor & Fix Loop


### PR DESCRIPTION
## What & why

`/resolve-pr-reviews` commits fixes, pushes, and replies to review threads, but it never updates the PR **description** — so after a few fix rounds the body can drift from the actual head (stale "Files changed" / "Tests" / release-impact). This adds a step to keep it current.

## Change

Adds a Phase 5 step to `.claude/commands/resolve-pr-reviews.md`: after pushing fixes, if they materially changed the PR (behaviour, files, tests, or release impact), edit the PR body via fetch-amend-set (`gh pr view --json body` → edit → `gh pr edit --body-file`, never a blind overwrite). Guidance:
- Keep it a current **summary**, not a per-commit changelog (commits + review replies already record each fix).
- Keep the **release-impact** line accurate per the root `CLAUDE.md` versioning convention.
- Skip it for pure comment/doc tweaks.

## Release impact

No release impact — command/docs change only, no published package touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)