### PR TITLE
chore: converge AI review loop on accepted tradeoffs

### DIFF
--- a/.claude/commands/fix-issue.md
+++ b/.claude/commands/fix-issue.md
@@ -110,6 +110,7 @@ After the plan is approved:
      - What changed and why (2-4 sentences, root cause for bugs)
      - Files changed with brief per-file notes
      - Tests added and what they cover
+     - A `## Design decisions / Accepted tradeoffs` section if the change makes a deliberate, debatable tradeoff (e.g. a breaking-but-intended choice) — so reviewers treat it as settled rather than re-flagging it each round
      - Any follow-up work, open questions, or coverage a maintainer must run manually (e.g. suites the quality gate is not allowed to run)
      
 ## Step 8: CI monitor & fix loop

--- a/.claude/commands/resolve-pr-reviews.md
+++ b/.claude/commands/resolve-pr-reviews.md
@@ -94,6 +94,10 @@ Draft: {yes|no}
 3. **CI failing, no unresolved comments** → Phase 6 (jump to CI fix).
 4. **Both reviewed + CI passing + nothing unresolved** (no comments needing action, or all already resolved) → Phase 7 (clean path).
 
+**What counts as "unresolved":** only **new, actionable** findings — defects, missing tests, doc/spec errors, or anything CRITICAL/HIGH. A finding is **not** unresolved (does not block, does not need a new commit) if it is: (a) a previously-accepted, by-design tradeoff recorded in the PR's "Design decisions / Accepted tradeoffs" section; (b) an item Claude placed under a "### Design notes" heading; or (c) a LOW the maintainer already adjudicated in a reply. Those are consensus, not open work.
+
+**Convergence / stop condition.** AI reviews are stateless and re-surface accepted tradeoffs every round, so "zero findings" is not the goal and is not always reachable. Treat the PR as **converged → Phase 7 (clean path)** once both reviewers cover the current head, CI is green, and every remaining finding falls under (a)–(c) above (no new CRITICAL/HIGH, no new actionable MEDIUM). Do not push new commits just to silence by-design notes. **Hard cap: after 3 resolve cycles with no new actionable finding, declare consensus and stop** — report it and leave the merge to the human.
+
 ---
 
 ## Phase 2: Address Review Comments
@@ -106,6 +110,7 @@ For each unresolved review comment or review with CHANGES_REQUESTED — this cov
    - ✅ **Already fixed** — a later commit addressed it
    - ❌ **False positive** — explain why the code is correct
    - 🔧 **Nit** — optional improvement, not blocking
+   - 🟰 **Accepted / by-design** — a real but intentional tradeoff, not a defect (e.g. a deliberate design choice already made and documented). Record it (see below) so it isn't re-litigated; do not re-fix it on later rounds.
 
 3. **Deduplicate** — bots (Claude, Copilot, Gemini) and humans often post the same finding. Group by actual issue.
 
@@ -114,7 +119,7 @@ Present a table:
 | # | Source | File:Line | Issue | Status | Planned Fix |
 |---|--------|-----------|-------|--------|-------------|
 
-Wait for user confirmation (unless `--fix` flag set), then proceed to Phase 3.
+Wait for user confirmation (unless `--fix` flag set). Once confirmed, **record any 🟰 accepted / by-design findings** in a `## Design decisions / Accepted tradeoffs` section of the PR description: fetch the body (`gh pr view {number} --repo {REPO} --json body --jq .body`), append a one-line entry stating the decision and why, then set it back (`gh pr edit {number} --repo {REPO} --body-file ...`). The `claude-review` prompt reads that section and will not re-raise listed items — this is the main lever that converges the loop. Then proceed to Phase 3.
 
 ---
 

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -154,8 +154,16 @@ jobs:
                - Resource cleanup and timeouts for TEE/deploy operations.
 
             4. Consolidate all agent findings and post exactly one comment on PR #${{ env.PR_NUMBER }}
-               using `gh pr comment ${{ env.PR_NUMBER }}`. If no issues were found, post
-               "No issues found." instead.
+               using `gh pr comment ${{ env.PR_NUMBER }}`.
+
+               Before listing anything, read the PR description — especially any "Design decisions" /
+               "Accepted tradeoffs" section — and the maintainer's replies on earlier review comments.
+               Anything adjudicated there is a settled decision: do NOT re-raise it. "Found N issues"
+               counts only NEW, actionable findings introduced by this PR (defects, missing tests,
+               doc/spec errors) — never by-design tradeoffs or already-accepted items. If a settled
+               tradeoff is still worth surfacing, mention it once under a trailing "### Design notes"
+               heading, not in the issue list or count. If there are no actionable findings, post
+               "No issues found." (a "### Design notes" section may still follow it).
 
             ### Code review
 
@@ -164,6 +172,10 @@ jobs:
             1. [SEVERITY:CONFIDENCE] <brief description>
 
             <permalink to file:line using full SHA, eg https://github.com/owner/repo/blob/abc123def/shade-agent-js/src/index.ts#L10-L15>
+
+            ### Design notes (optional)
+
+            - <a by-design tradeoff or already-accepted item worth noting once — excluded from the "Found N" count>
 
             IMPORTANT rules:
             - Only YOU (the main process) may call `gh pr comment`. Agents must return
@@ -174,3 +186,6 @@ jobs:
             - Do NOT build or test the code.
             - Ignore pre-existing issues not introduced by this PR.
             - Ignore issues a linter/compiler would catch.
+            - Do NOT re-raise an issue the PR description's "Design decisions" / "Accepted tradeoffs"
+              section, or a maintainer reply on a prior review round, already documents as intentional.
+              Surface it (if at all) once under "### Design notes", never in "Found N issues".


### PR DESCRIPTION
## What & why

PR #95 went ~10 review rounds without "consensus" — not because of open defects (the one real bug was fixed in round 1), but because the loop can't terminate on a deliberate, documented tradeoff. AI reviews are **stateless**: each round re-derives from scratch and re-flags the same by-design property (the exact-deposit coupling), so "zero findings" is unreachable, and every push (even a 1-line doc tweak) resets the gate. This gives the loop a real stop condition and lets it carry state across rounds.

## Changes

- **`.github/workflows/claude-review.yml`** — the reviewer now reads the PR's "Design decisions / Accepted tradeoffs" section + prior maintainer replies and **must not re-raise settled decisions**. "Found N issues" counts only **new, actionable** findings; by-design / already-accepted items go under a separate **`### Design notes`** heading, excluded from the count.
- **`.claude/commands/resolve-pr-reviews.md`** — adds a **🟰 Accepted / by-design** classification, recorded in the PR's "Design decisions / Accepted tradeoffs" section (fetch-amend-set) so the reviewer prompt and future rounds stop re-litigating it; defines **"unresolved" as new actionable findings only**; adds a **convergence / stop condition** (both reviewers on current head + CI green + only LOW/accepted remain → done) with a **3-cycle hard cap**.
- **`.claude/commands/fix-issue.md`** — seeds a "Design decisions / Accepted tradeoffs" PR-body section when a change makes a deliberate tradeoff.

The accepted-tradeoffs section is the key lever: it is the shared state the (otherwise stateless) reviewer reads, so a decision made once isn't re-surfaced as a fresh finding every round.

## Release impact

No release impact — CI workflow + command docs only, no published package touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)