### PR TITLE
ci: make /run-e2e a manual, non-blocking suite on main and stable PRs

### DIFF
--- a/.claude/project-specifics/pr-quality-gate.md
+++ b/.claude/project-specifics/pr-quality-gate.md
@@ -7,7 +7,7 @@ Run this before committing and opening a PR into `main`. Work through it top to 
 ## Hard rules (read first)
 
 1. **Only run the checks for the area(s) your diff actually touched.** This is a monorepo; a docs-only or single-package change does not need every gate.
-2. **Never run the end-to-end / sandbox-integration suites in this gate.** `tests-in-tee/` and the heavy `shade-contract-template` sandbox integration tests (`cargo test`, not `--lib`) need live testnet NEAR accounts, a funded sponsor account, and a `PHALA_API_KEY` — real infrastructure, credentials, and cost. They run on the `main → stable` promotion via the manual `/run-e2e` gate (`.github/workflows/e2e.yml`). Flag them in the PR for a maintainer to run; do not run them here.
+2. **Never run the end-to-end / sandbox-integration suites in this gate.** `tests-in-tee/` and the heavy `shade-contract-template` sandbox integration tests (`cargo test`, not `--lib`) need live testnet NEAR accounts, a funded sponsor account, and a `PHALA_API_KEY` — real infrastructure, credentials, and cost. They run via the manual, non-blocking `/run-e2e` suite (`.github/workflows/e2e.yml`), which a maintainer can trigger on a `main` or `stable` PR. Flag them in the PR for a maintainer to run; do not run them here.
 3. **Rebuild `shade-agent-js` before building anything that consumes it.** `shade-agent-template` (and `tests-in-tee`) import `@neardefi/shade-agent-js` via `file:../shade-agent-js`, whose `dist/` (including the `.d.cts` types) is gitignored and has no `prepare` script — so `npm run build` the library first or `tsc` cannot resolve the import.
 4. **A change to `shade-attestation` is a breaking change to `shade-contract-template`.** Run the contract gate whenever you touch the attestation crate.
 5. Use `npm i` (not only `npm ci`) when you changed a `package.json`, so the lockfile is reconciled.
@@ -91,7 +91,7 @@ cd shade-contract-template
 cargo fmt
 cargo clippy --all-targets
 cargo test --lib      # unit tests only — fast. The full `cargo test` (sandbox integration)
-                      # and the wasm build run in the /run-e2e gate on main->stable — NOT here.
+                      # and the wasm build run in the manual /run-e2e suite — NOT here.
 cd ..
 ```
 
@@ -110,7 +110,7 @@ cargo clippy --all-targets   # CI runs the same; clippy is lenient (no -D warnin
                              # still fix every warning your change introduces
 ```
 
-These are the **fixing** flavor — they rewrite files and surface problems so you fix them here, before pushing. CI (`.github/workflows/ci.yml`) runs the **check** counterpart (`cargo fmt --check`, `cargo clippy --all-targets`, the same `npm run build`/`npm test`) on every PR into `main` and fails on anything left unaddressed, so a clean run here is what makes CI green. **CI is the authority** — its per-area path filtering and the heavier `main → stable` `/run-e2e` gate (`.github/workflows/e2e.yml`) define the full enforcement set; this gate is the local superset that keeps it green.
+These are the **fixing** flavor — they rewrite files and surface problems so you fix them here, before pushing. CI (`.github/workflows/ci.yml`) runs the **check** counterpart (`cargo fmt --check`, `cargo clippy --all-targets`, the same `npm run build`/`npm test`) on every PR into `main` and fails on anything left unaddressed, so a clean run here is what makes CI green. **CI is the authority** — its per-area path filtering defines the required `ci-passed` check on every PR into `main`; the heavier `/run-e2e` suite (`.github/workflows/e2e.yml`) is a separate, manually-triggered, **non-blocking** suite. This local gate is the superset that keeps `ci-passed` green.
 
 ---
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,8 @@ name: CI
 
 on:
   # Runs on PRs into main (the fast feedback loop) and also re-runs on
-  # main->stable promotion PRs, which are additionally gated by the manual
-  # /run-e2e heavy suite (see e2e.yml).
+  # main->stable promotion PRs. The heavy /run-e2e suite (see e2e.yml) can be
+  # run manually on main or stable PRs; it's non-blocking.
   pull_request:
     branches: [main, stable]
   push:
@@ -151,10 +151,10 @@ jobs:
       # clippy --all-targets still compiles the integration-test code, so test
       # compile breakage surfaces here; only the slow sandbox *runtime* (the
       # tests/*.rs integration tests) plus the wasm build move to the manual
-      # /run-e2e gate on main->stable PRs (see .github/workflows/e2e.yml).
+      # /run-e2e suite (see .github/workflows/e2e.yml).
       - run: cargo clippy --all-targets
       # Unit tests only — fast. The full `cargo test` (sandbox integration
-      # tests) runs in the /run-e2e gate.
+      # tests) runs in the /run-e2e suite.
       - run: cargo test --lib
 
   # Single required status check. Succeeds if every needed job either passed or

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,13 +1,16 @@
 name: E2E (manual gate)
 
 # Heavy end-to-end suite (contract sandbox integration tests + tests-in-tee
-# against a real Phala TDX CVM) for main->stable promotion PRs.
+# against a real Phala TDX CVM). Runnable on PRs into `stable` and `main`.
 #
 # It does NOT run automatically on PR open / new commits. A maintainer comments
-# `/run-e2e` on the PR; this workflow runs the suite and reports a required
-# `e2e/required` commit status on the PR head commit. So a promotion stays
-# blocked until the suite has been manually run and passed on the *current*
-# commit (a new commit clears the status and requires re-running).
+# `/run-e2e` on the PR; this workflow runs the suite and reports a commit status
+# on the PR head commit:
+#   - base `stable`: `e2e/required` — a REQUIRED check, so a main->stable
+#     promotion stays blocked until the suite has been run and passed on the
+#     *current* commit (a new commit clears the status and requires re-running).
+#   - base `main`: `e2e/optional` — informational only; `main`'s ruleset does not
+#     require it, so it never blocks merge. Lets you run e2e on a main PR on demand.
 #
 # NOTE: issue_comment workflows always use the workflow file from the default
 # branch, so edits here only take effect once merged to main.
@@ -44,6 +47,7 @@ jobs:
       proceed: ${{ steps.resolve.outputs.proceed }}
       head_sha: ${{ steps.resolve.outputs.head_sha }}
       head_ref: ${{ steps.resolve.outputs.head_ref }}
+      status_context: ${{ steps.resolve.outputs.status_context }}
     steps:
       - uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         id: resolve
@@ -57,9 +61,9 @@ jobs:
             const headRef = pr.data.head.ref;
             const isFork = pr.data.head.repo.fork;
 
-            // Only gate promotions into stable.
-            if (baseRef !== 'stable') {
-              core.notice(`/run-e2e ignored: base branch is '${baseRef}', not 'stable'.`);
+            // Runnable on stable promotions and on main PRs; anything else is ignored.
+            if (baseRef !== 'stable' && baseRef !== 'main') {
+              core.notice(`/run-e2e ignored: base branch is '${baseRef}', not 'stable' or 'main'.`);
               core.setOutput('proceed', 'false');
               return;
             }
@@ -72,18 +76,23 @@ jobs:
             // Trigger access (PiVortex, org MEMBER) is enforced by the job-level
             // `if:` above, so no runtime permission lookup is needed here.
 
+            // stable promotions report the REQUIRED `e2e/required` check (blocks merge);
+            // main PRs report an informational `e2e/optional` check that does not gate merge.
+            const statusContext = baseRef === 'stable' ? 'e2e/required' : 'e2e/optional';
+
             core.setOutput('proceed', 'true');
             core.setOutput('head_sha', headSha);
             core.setOutput('head_ref', headRef);
+            core.setOutput('status_context', statusContext);
 
-            // Acknowledge and mark the required check pending on the PR head commit.
+            // Acknowledge and mark the check pending on the PR head commit.
             const runUrl = `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`;
             await github.rest.reactions.createForIssueComment({
               owner, repo, comment_id: context.payload.comment.id, content: 'eyes',
             });
             await github.rest.repos.createCommitStatus({
               owner, repo, sha: headSha,
-              state: 'pending', context: 'e2e/required',
+              state: 'pending', context: statusContext,
               description: 'Running e2e suite…', target_url: runUrl,
             });
             await github.rest.issues.createComment({
@@ -215,6 +224,7 @@ jobs:
       - uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         env:
           HEAD_SHA: ${{ needs.guard.outputs.head_sha }}
+          STATUS_CONTEXT: ${{ needs.guard.outputs.status_context }}
           R_WASM: ${{ needs.build-wasm.result }}
           R_INT: ${{ needs.contract-integration.result }}
           R_TEE: ${{ needs.tests-in-tee.result }}
@@ -227,7 +237,7 @@ jobs:
             await github.rest.repos.createCommitStatus({
               owner, repo, sha: process.env.HEAD_SHA,
               state: ok ? 'success' : 'failure',
-              context: 'e2e/required',
+              context: process.env.STATUS_CONTEXT,
               description: ok ? 'e2e suite passed' : 'e2e suite failed',
               target_url: runUrl,
             });

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,16 +1,13 @@
-name: E2E (manual gate)
+name: E2E (manual)
 
 # Heavy end-to-end suite (contract sandbox integration tests + tests-in-tee
-# against a real Phala TDX CVM). Runnable on PRs into `stable` and `main`.
+# against a real Phala TDX CVM). Runnable on demand on PRs into `main` or `stable`.
 #
-# It does NOT run automatically on PR open / new commits. A maintainer comments
-# `/run-e2e` on the PR; this workflow runs the suite and reports a commit status
-# on the PR head commit:
-#   - base `stable`: `e2e/required` — a REQUIRED check, so a main->stable
-#     promotion stays blocked until the suite has been run and passed on the
-#     *current* commit (a new commit clears the status and requires re-running).
-#   - base `main`: `e2e/optional` — informational only; `main`'s ruleset does not
-#     require it, so it never blocks merge. Lets you run e2e on a main PR on demand.
+# It does NOT run automatically on PR open / new commits, and it is NON-BLOCKING:
+# a maintainer comments `/run-e2e` on the PR; this workflow runs the suite and
+# reports an informational `e2e` commit status on the PR head commit. Neither the
+# `main` nor `stable` ruleset requires that status, so it never gates merge — it
+# just surfaces the result (re-run after a new commit to refresh it).
 #
 # NOTE: issue_comment workflows always use the workflow file from the default
 # branch, so edits here only take effect once merged to main.
@@ -34,8 +31,8 @@ jobs:
   guard:
     # Lock the heavy e2e suite to PiVortex (a NearDeFi org member) only, via
     # `/run-e2e` on a PR in this repo — mirrors the claude-review trigger gate.
-    # The base-branch (must be stable) and not-a-fork checks run in `resolve`
-    # below, since they need the PR API that an `if:` expression can't call.
+    # The base-branch (must be main or stable) and not-a-fork checks run in
+    # `resolve` below, since they need the PR API that an `if:` expression can't call.
     if: >-
       github.repository == 'NearDeFi/shade-agent-framework' &&
       github.event.comment.user.login == 'PiVortex' &&
@@ -47,7 +44,6 @@ jobs:
       proceed: ${{ steps.resolve.outputs.proceed }}
       head_sha: ${{ steps.resolve.outputs.head_sha }}
       head_ref: ${{ steps.resolve.outputs.head_ref }}
-      status_context: ${{ steps.resolve.outputs.status_context }}
     steps:
       - uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         id: resolve
@@ -76,23 +72,18 @@ jobs:
             // Trigger access (PiVortex, org MEMBER) is enforced by the job-level
             // `if:` above, so no runtime permission lookup is needed here.
 
-            // stable promotions report the REQUIRED `e2e/required` check (blocks merge);
-            // main PRs report an informational `e2e/optional` check that does not gate merge.
-            const statusContext = baseRef === 'stable' ? 'e2e/required' : 'e2e/optional';
-
             core.setOutput('proceed', 'true');
             core.setOutput('head_sha', headSha);
             core.setOutput('head_ref', headRef);
-            core.setOutput('status_context', statusContext);
 
-            // Acknowledge and mark the check pending on the PR head commit.
+            // Acknowledge and post the (informational, non-blocking) `e2e` status pending.
             const runUrl = `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`;
             await github.rest.reactions.createForIssueComment({
               owner, repo, comment_id: context.payload.comment.id, content: 'eyes',
             });
             await github.rest.repos.createCommitStatus({
               owner, repo, sha: headSha,
-              state: 'pending', context: statusContext,
+              state: 'pending', context: 'e2e',
               description: 'Running e2e suite…', target_url: runUrl,
             });
             await github.rest.issues.createComment({
@@ -215,7 +206,7 @@ jobs:
             echo "No .cvm-id file; nothing to tear down."
           fi
 
-  # Post the final required status on the PR head commit.
+  # Post the final (informational) e2e status on the PR head commit.
   report:
     needs: [guard, build-wasm, contract-integration, tests-in-tee]
     if: ${{ always() && needs.guard.outputs.proceed == 'true' }}
@@ -224,7 +215,6 @@ jobs:
       - uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         env:
           HEAD_SHA: ${{ needs.guard.outputs.head_sha }}
-          STATUS_CONTEXT: ${{ needs.guard.outputs.status_context }}
           R_WASM: ${{ needs.build-wasm.result }}
           R_INT: ${{ needs.contract-integration.result }}
           R_TEE: ${{ needs.tests-in-tee.result }}
@@ -237,7 +227,7 @@ jobs:
             await github.rest.repos.createCommitStatus({
               owner, repo, sha: process.env.HEAD_SHA,
               state: ok ? 'success' : 'failure',
-              context: process.env.STATUS_CONTEXT,
+              context: 'e2e',
               description: ok ? 'e2e suite passed' : 'e2e suite failed',
               target_url: runUrl,
             });

--- a/tests-in-tee/README.md
+++ b/tests-in-tee/README.md
@@ -74,12 +74,12 @@ CI can delete it as a backstop if the process is killed before cleanup runs.
 
 ## Running in CI
 
-This suite is the heavy gate for `main` → `stable` promotion PRs. It does **not**
-run on every commit. A maintainer comments **`/run-e2e`** on the promotion PR and
-the `E2E (manual gate)` workflow (`.github/workflows/e2e.yml`) runs the contract
-integration tests and this suite, then reports a required `e2e/required` status
-on the PR. The contract wasm is built once and shared with both jobs via an
-artifact.
+This suite does **not** run on every commit. A maintainer comments **`/run-e2e`**
+on a PR into `main` or `stable` and the `E2E (manual)` workflow
+(`.github/workflows/e2e.yml`) runs the contract integration tests and this suite,
+then reports a single informational `e2e` status on the PR. That status is
+**non-blocking** — it never gates merge. The contract wasm is built once and
+shared with both jobs via an artifact.
 
 CI supplies the same inputs as the local `.env` via repository secrets:
 `TESTNET_ACCOUNT_ID`, `TESTNET_PRIVATE_KEY`, `PHALA_API_KEY` (and optionally


### PR DESCRIPTION
## What & why

Two changes make the heavy e2e suite (contract sandbox integration + tests-in-tee) **manually runnable on `main` PRs and non-blocking everywhere**:

1. **Ruleset (done out-of-band):** `e2e/required` was removed from the **`stable`** ruleset's required checks. Both `main` and `stable` now require only **`ci-passed`**, so e2e gates no merge.
2. **Workflow (`.github/workflows/e2e.yml`):** `/run-e2e` previously ignored any PR whose base wasn't `stable`. It now runs on PRs into **`main` or `stable`**, and reports a single **informational `e2e` commit status** (no longer the `e2e/required` vs `e2e/optional` split — nothing requires e2e anymore, so one context is honest). Forks are still rejected (no secrets).

Net: a maintainer can comment `/run-e2e` on a `main` or `stable` PR to run the suite on demand; the result shows as an `e2e` check on the PR but never blocks merge.

## Changes

- **`.github/workflows/e2e.yml`** — `guard` accepts base `main` or `stable`; posts/finishes a single `e2e` status (dropped the `status_context` output and the required/optional split); workflow renamed `E2E (manual)`; header rewritten to describe it as non-blocking.
- **`.github/workflows/ci.yml`** — comments no longer call `/run-e2e` a `main→stable` gate.
- **`.claude/project-specifics/pr-quality-gate.md`** — describes `/run-e2e` as a manual, non-blocking suite runnable on main or stable (was: a blocking `main → stable` gate). The "don't run e2e/sandbox locally; flag for a maintainer" guidance is unchanged.

Takes effect once merged to `main` (issue_comment workflows use the default-branch copy).

## Release impact

No release impact — CI workflow + internal docs only, no published package touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)