### PR TITLE
chore: let /fix-issue accept a free-text problem (and commit /auto-resolve-pr)

### DIFF
--- a/.claude/commands/auto-resolve-pr.md
+++ b/.claude/commands/auto-resolve-pr.md
@@ -56,7 +56,7 @@ Gather state:
 gh api --paginate repos/{REPO}/issues/{number}/comments
 gh api --paginate repos/{REPO}/pulls/{number}/reviews
 gh pr view {number} --repo {REPO} --json reviewRequests
-gh pr checks {number} --repo {REPO} --json name,status,conclusion
+gh pr checks {number} --repo {REPO} --json name,bucket   # bucket: pending|pass|fail|skipping|cancel
 ```
 
 For **each** reviewer, decide what to do — **trigger only if neither a fresh review nor a pending request exists**. Mostly this fires only at cold start (pass 1): after any pass that pushed a fix, `resolve-pr-reviews` has already re-requested both reviewers, so this command finds them pending and just waits — it does not re-trigger.
@@ -77,7 +77,7 @@ If the Claude workflow doesn't start (it fires only when `claude-review.yml` is 
 **Poll until ready.** Re-check roughly every 30s (do **not** use `gh ... --watch` — it can hang; the `Monitor` tool with a poll-until-condition loop is the cleanest way to wait), until **both reviews are fresh AND CI is non-pending**, or **~15 minutes** have elapsed:
 
 1. Re-run the four queries above.
-2. Both reviews fresh (postdate the head commit) **AND** no CI check still `queued`/`in_progress` → exit the loop and go to Step C. (CI may be red — `resolve-pr-reviews` repairs that next.)
+2. Both reviews fresh (postdate the head commit) **AND** no CI check still in the `pending` bucket → exit the loop and go to Step C. (CI may be red — `bucket` `fail` — `resolve-pr-reviews` repairs that next.)
 3. Otherwise wait ~30s and repeat.
 
 On the 15-minute timeout, report which reviewer or check never landed and **STOP** with outcome `REVIEW_TIMEOUT`. Claude's review is the slow path (opus, xhigh, 4 parallel agents), so expect it to take several minutes.
@@ -90,12 +90,14 @@ This loop is **hands-off**, so never wait on an interactive prompt: if the deleg
 
 `resolve-pr-reviews` runs the repo's area-specific quality gate, which needs tools (`npm`, `cargo`, …) from **its own** allowlist — allowlists are per-command, so this command's allowlist doesn't extend to the delegated pass. If that pass can't run a required gate command (a tool-policy/permission stop), **STOP** with outcome `HARD_STOP` and report it as a command-config issue (a missing grant in `resolve-pr-reviews`), not a PR-specific failure.
 
+Before any **STOP** that exits from this step (the CI-timeout `REVIEW_TIMEOUT` or the gate `HARD_STOP`), first update the commit accounting — `resolve-pr-reviews` pushes its fix commits before the CI step, so a pass can push and then stop here: re-read the `commits` length as `commit_count_after` and add `commit_count_after - commit_count_before` to `total_commits_pushed`, so the Phase 3 report counts the push honestly.
+
 ### Step D — Decide (machine-checkable, not from prose)
 
 Re-read the head, CI, and **both** comment surfaces — the `resolve-pr-reviews` clean-path signal, `Reviews passed!`, is an **issue** comment, not a PR review comment, so you must fetch issue comments to detect convergence:
 ```
 gh pr view {number} --repo {REPO} --json headRefOid,commits
-gh pr checks {number} --repo {REPO} --json name,status,conclusion
+gh pr checks {number} --repo {REPO} --json name,bucket   # bucket: pending|pass|fail|skipping|cancel
 gh api --paginate repos/{REPO}/pulls/{number}/comments     # inline review comments
 gh api --paginate repos/{REPO}/issues/{number}/comments     # incl. any `Reviews passed!` newer than the head
 ```

--- a/.claude/commands/auto-resolve-pr.md
+++ b/.claude/commands/auto-resolve-pr.md
@@ -1,7 +1,7 @@
 ---
 description: Loop the PR review→fix cycle to consensus — kick off the reviews if none are pending, wait for Claude+Copilot & CI, run resolve-pr-reviews (--fix), repeat up to 5×; never merges
 disable-model-invocation: true
-allowed-tools: Bash(gh pr view:*), Bash(gh pr diff:*), Bash(gh pr comment:*), Bash(gh pr checks:*), Bash(gh pr edit:*), Bash(gh pr list:*), Bash(gh pr checkout:*), Bash(gh api:*), Bash(gh repo view:*), Bash(gh run view:*), Bash(git diff:*), Bash(git log:*), Bash(git fetch:*), Bash(git checkout:*), Bash(git status:*), Bash(git branch:*), Bash(git add:*), Bash(git commit:*), Bash(git push:*), Bash(npm ci:*), Bash(npm install:*), Bash(npm i:*), Bash(npm run build:*), Bash(npm test:*), Bash(npm run test:*), Bash(cargo fmt:*), Bash(cargo clippy:*), Bash(cargo test:*), Bash(cargo check:*), Read, Edit, Write, Grep, Glob, Agent
+allowed-tools: Bash(gh pr view:*), Bash(gh pr diff:*), Bash(gh pr comment:*), Bash(gh pr checks:*), Bash(gh pr edit:*), Bash(gh pr list:*), Bash(gh pr checkout:*), Bash(gh api:*), Bash(gh repo view:*), Bash(gh run view:*), Bash(git diff:*), Bash(git log:*), Bash(git fetch:*), Bash(git checkout:*), Bash(git status:*), Bash(git branch:*), Bash(git add:*), Bash(git commit:*), Bash(git push:*), Bash(npm ci:*), Bash(npm install:*), Bash(npm i:*), Bash(npm run build:*), Bash(npm test:*), Bash(npm run test:*), Bash(cargo fmt:*), Bash(cargo clippy:*), Bash(cargo test:*), Bash(cargo check:*), Read, Edit, Write, Grep, Glob, Agent, Monitor
 argument-hint: "<pr-number or url>"
 ---
 
@@ -74,7 +74,7 @@ gh api --method POST repos/{REPO}/pulls/{number}/requested_reviewers -f "reviewe
 ```
 If the Claude workflow doesn't start (it fires only when `claude-review.yml` is on the default branch and the authenticated `gh` user is the configured trigger user), note it and **STOP** — don't spin. If the Copilot request errors (no Copilot access / quota), note it and **STOP**.
 
-**Poll until ready.** Repeat, with ~30s between iterations (do **not** use `gh ... --watch` — it can hang; wait with a backgrounded `sleep 30` re-check or the `Monitor` tool), until **both reviews are fresh AND CI is non-pending**, or **~15 minutes** have elapsed:
+**Poll until ready.** Re-check roughly every 30s (do **not** use `gh ... --watch` — it can hang; the `Monitor` tool with a poll-until-condition loop is the cleanest way to wait), until **both reviews are fresh AND CI is non-pending**, or **~15 minutes** have elapsed:
 
 1. Re-run the four queries above.
 2. Both reviews fresh (postdate the head commit) **AND** no CI check still `queued`/`in_progress` → exit the loop and go to Step C. (CI may be red — `resolve-pr-reviews` repairs that next.)
@@ -88,20 +88,21 @@ Read `.claude/commands/resolve-pr-reviews.md` and execute its full flow for PR #
 
 ### Step D — Decide (machine-checkable, not from prose)
 
-Re-read the head and recount the unresolved comments + CI:
+Re-read the head, CI, and **both** comment surfaces — the `resolve-pr-reviews` clean-path signal, `Reviews passed!`, is an **issue** comment, not a PR review comment, so you must fetch issue comments to detect convergence:
 ```
 gh pr view {number} --repo {REPO} --json headRefOid
-gh api --paginate repos/{REPO}/pulls/{number}/comments
 gh pr checks {number} --repo {REPO} --json name,status,conclusion
+gh api --paginate repos/{REPO}/pulls/{number}/comments     # inline review comments
+gh api --paginate repos/{REPO}/issues/{number}/comments     # incl. any `Reviews passed!` newer than the head
 ```
 Let `head_after` be the new `headRefOid`. If `head_after != head_before`, increment `total_commits_pushed` by the number of new commits.
 
-Classify the pass:
+Classify the pass **in this order — the first match wins**. Hard stop and Stall are checked *before* the head-changed test, because an unrecoverable pass can also have pushed commits (so a naive "head changed → Progress" would loop on a failing pass):
 
-- **Converged** ⇔ `head_after == head_before` **AND** CI green **AND** zero unresolved review comments **AND** both reviews fresh. This is exactly the `resolve-pr-reviews` clean path (it posted `Reviews passed!`). → **STOP — success.**
-- **Progress** ⇔ `head_after != head_before` (the pass pushed fixes; `resolve-pr-reviews` already re-requested both reviewers against the new head). → loop back to **Step A**. Step B will see the pending requests and just wait for the fresh reviews.
-- **Stall** ⇔ `head_after == head_before` **but not converged** (e.g. a finding it classified as a false positive that a reviewer keeps reopening, or something it couldn't fix). Re-running would reproduce an identical state. → **STOP — report.** This is also the infinite-loop guard.
-- **Hard stop** ⇔ `resolve-pr-reviews` stopped unrecoverably (CI `STILL_FAILING` after its 3 attempts, a finding it couldn't classify or fix, or a review trigger that never fired). → **STOP — report.**
+- **Hard stop** ⇔ `resolve-pr-reviews` stopped unrecoverably this pass (CI `STILL_FAILING` after its 3 attempts, a finding it couldn't classify or fix, or a review trigger that never fired). → **STOP — report** (outcome `STILL_FAILING` for the CI case, otherwise `HARD_STOP`).
+- **Converged** ⇔ `head_after == head_before` **AND** CI green **AND** `resolve-pr-reviews` took its clean path (a `Reviews passed!` issue comment newer than the head). → **STOP — success.**
+- **Progress** ⇔ `head_after != head_before` (the pass pushed fixes and `resolve-pr-reviews` already re-requested both reviewers against the new head). → loop back to **Step A**; Step B will see the pending requests and just wait for the fresh reviews.
+- **Stall** ⇔ `head_after == head_before` **but not converged** (e.g. a finding it classified as a false positive that a reviewer keeps reopening). Re-running would reproduce an identical state. → **STOP — report.** This is also the infinite-loop guard.
 
 ---
 
@@ -120,7 +121,7 @@ PR #{number}: {title}
 Passes run: {N}/5
 Commits pushed: {total_commits_pushed}
 CI: {PASS|FAIL|PENDING}
-Outcome: {CONVERGED | REVIEW_TIMEOUT | STILL_FAILING | STALL | CAP_REACHED}
+Outcome: {CONVERGED | REVIEW_TIMEOUT | STILL_FAILING | HARD_STOP | STALL | CAP_REACHED}
 ```
 
 In prose: per-pass summary (what each pass fixed / pushed), the final CI status, whether consensus was reached (`Reviews passed!` posted on the final clean pass) or which reviewer / finding / check still blocks it, and the stop reason if it didn't converge. Remind the user that this command **never merges** — that decision belongs to a human.
@@ -135,4 +136,4 @@ In prose: per-pass summary (what each pass fixed / pushed), the final CI status,
 - **Same freshness rule as `resolve-pr-reviews`.** A review counts only if it postdates the current head commit; stale reviews are treated as missing.
 - **Trigger only at cold start.** Kick off a review only when neither a fresh review nor a pending request exists. After a fix-pushing pass, `resolve-pr-reviews` has already re-requested both — just wait; never double-request across the handoff.
 - **Stop on stall and on hard failure.** Don't waste passes re-running an unchanged, unconverged state.
-- **No `--watch`; poll every ~30s** (backgrounded `sleep 30` re-check or the `Monitor` tool) with a ~15-minute timeout on the wait step.
+- **No `--watch`; poll every ~30s** (the `Monitor` tool with a poll-until-condition loop is cleanest) with a ~15-minute timeout on the wait step.

--- a/.claude/commands/auto-resolve-pr.md
+++ b/.claude/commands/auto-resolve-pr.md
@@ -88,6 +88,8 @@ Read `.claude/commands/resolve-pr-reviews.md` and execute its full flow for PR #
 
 This loop is **hands-off**, so never wait on an interactive prompt: if the delegated CI step (`check-and-fix-ci`) hits its ~10-minute pending timeout and would *"ask the user whether to keep waiting"*, do **not** block — treat it as the delegated pass not settling and **STOP** with outcome `REVIEW_TIMEOUT`, reporting that CI never settled.
 
+`resolve-pr-reviews` runs the repo's area-specific quality gate, which needs tools (`npm`, `cargo`, …) from **its own** allowlist — allowlists are per-command, so this command's allowlist doesn't extend to the delegated pass. If that pass can't run a required gate command (a tool-policy/permission stop), **STOP** with outcome `HARD_STOP` and report it as a command-config issue (a missing grant in `resolve-pr-reviews`), not a PR-specific failure.
+
 ### Step D — Decide (machine-checkable, not from prose)
 
 Re-read the head, CI, and **both** comment surfaces — the `resolve-pr-reviews` clean-path signal, `Reviews passed!`, is an **issue** comment, not a PR review comment, so you must fetch issue comments to detect convergence:

--- a/.claude/commands/auto-resolve-pr.md
+++ b/.claude/commands/auto-resolve-pr.md
@@ -1,0 +1,138 @@
+---
+description: Loop the PR review→fix cycle to consensus — kick off the reviews if none are pending, wait for Claude+Copilot & CI, run resolve-pr-reviews (--fix), repeat up to 5×; never merges
+disable-model-invocation: true
+allowed-tools: Bash(gh pr view:*), Bash(gh pr diff:*), Bash(gh pr comment:*), Bash(gh pr checks:*), Bash(gh pr edit:*), Bash(gh pr list:*), Bash(gh pr checkout:*), Bash(gh api:*), Bash(gh repo view:*), Bash(gh run view:*), Bash(git diff:*), Bash(git log:*), Bash(git fetch:*), Bash(git checkout:*), Bash(git status:*), Bash(git branch:*), Bash(git add:*), Bash(git commit:*), Bash(git push:*), Bash(npm ci:*), Bash(npm install:*), Bash(npm i:*), Bash(npm run build:*), Bash(npm test:*), Bash(npm run test:*), Bash(cargo fmt:*), Bash(cargo clippy:*), Bash(cargo test:*), Bash(cargo check:*), Read, Edit, Write, Grep, Glob, Agent
+argument-hint: "<pr-number or url>"
+---
+
+# Auto-Resolve PR
+
+Drive `/resolve-pr-reviews` to consensus in a capped loop: **wait** for the Claude + Copilot reviews and CI to land on the current head (kicking the reviews off only if nothing is already pending), run `resolve-pr-reviews` fully autonomously (`--fix`), then repeat — at most **5 passes** — until the PR converges or hits a hard stop.
+
+`resolve-pr-reviews` already does one full pass (classify → fix → quality-gate → push → fix CI → re-request both reviewers) and **stops** when the AI reviews are missing or stale, telling a human to trigger the reviewers and re-run. This command is that human-in-the-loop. It owns **waiting + looping**, and triggers reviews only to fill the gap `resolve-pr-reviews` leaves: at **cold start**, when no review or request exists yet, so the first delegated pass doesn't immediately stop. After any pass that pushes a fix, `resolve-pr-reviews` itself re-requests both reviewers — so on later passes this command only **waits** on those pending requests, it does not re-trigger. It delegates **all classification, fixing, replying, and CI repair** to `resolve-pr-reviews` and reimplements none of it.
+
+**This command never merges. Merging is a human decision.**
+
+## Phase 0: Resolve repo & parse args
+
+Resolve the target repository from the current clone:
+
+```
+gh repo view --json nameWithOwner --jq .nameWithOwner
+```
+
+Call it `{REPO}` and use it in every `gh` command below. If the command fails (not a git repository, or no GitHub remote), stop and ask the user for the repository.
+
+Parse `$ARGUMENTS` for the PR number:
+- Extract from a bare number or a `https://github.com/owner/repo/pull/123` URL.
+- If absent, detect from the current branch: `gh pr list --head $(git branch --show-current) --repo {REPO} --json number --jq '.[0].number'`
+- If still nothing, stop and ask the user.
+
+Set `MAX_PASSES = 5`. Track `total_commits_pushed = 0` and a per-pass log for the final report.
+
+---
+
+## Phase 1: Convergence loop
+
+Repeat for `pass = 1 .. MAX_PASSES`. Announce the pass number at the start of each iteration.
+
+### Step A — Snapshot the head
+
+```
+gh pr view {number} --repo {REPO} --json headRefOid,commits
+```
+
+Record `headRefOid` (call it `head_before`) and the last commit's `committedDate`. These define "current head" for the freshness checks in Step B and for detecting whether this pass pushed anything in Step D.
+
+### Step B — Ensure both reviews are fresh + CI complete (the wait)
+
+A review counts only if it was posted **after** `committedDate` (same freshness rule as `resolve-pr-reviews`). A review of an earlier commit is **stale** — treat it as missing.
+
+- **Claude reviewed** ⇔ an issue comment by `github-actions[bot]` matching the claude-review output contract (contains `### Code review`, `Found N issues`, or `No issues found.`) that is newer than the head commit.
+- **Copilot reviewed** ⇔ a review in `pulls/{number}/reviews` by `copilot-pull-request-reviewer[bot]` newer than the head commit.
+
+Gather state:
+```
+gh api --paginate repos/{REPO}/issues/{number}/comments
+gh api --paginate repos/{REPO}/pulls/{number}/reviews
+gh pr view {number} --repo {REPO} --json reviewRequests
+gh pr checks {number} --repo {REPO} --json name,status,conclusion
+```
+
+For **each** reviewer, decide what to do — **trigger only if neither a fresh review nor a pending request exists**. Mostly this fires only at cold start (pass 1): after any pass that pushed a fix, `resolve-pr-reviews` has already re-requested both reviewers, so this command finds them pending and just waits — it does not re-trigger.
+
+| State of this reviewer | Action |
+|---|---|
+| Fresh review present (newer than head) | Done — nothing to do |
+| Request already pending (Copilot in `reviewRequests`, or a `/claude-review` comment newer than head) | Don't trigger — just wait (already requested) |
+| Neither (cold start) | Trigger it (below), then wait |
+
+Triggers (only for the "neither" case):
+```
+gh pr comment {number} --repo {REPO} --body "/claude-review"
+gh api --method POST repos/{REPO}/pulls/{number}/requested_reviewers -f "reviewers[]=copilot-pull-request-reviewer[bot]"
+```
+If the Claude workflow doesn't start (it fires only when `claude-review.yml` is on the default branch and the authenticated `gh` user is the configured trigger user), note it and **STOP** — don't spin. If the Copilot request errors (no Copilot access / quota), note it and **STOP**.
+
+**Poll until ready.** Repeat, with ~30s between iterations (do **not** use `gh ... --watch` — it can hang; wait with a backgrounded `sleep 30` re-check or the `Monitor` tool), until **both reviews are fresh AND CI is non-pending**, or **~15 minutes** have elapsed:
+
+1. Re-run the four queries above.
+2. Both reviews fresh (postdate the head commit) **AND** no CI check still `queued`/`in_progress` → exit the loop and go to Step C. (CI may be red — `resolve-pr-reviews` repairs that next.)
+3. Otherwise wait ~30s and repeat.
+
+On the 15-minute timeout, report which reviewer or check never landed and **STOP** with outcome `REVIEW_TIMEOUT`. Claude's review is the slow path (opus, xhigh, 4 parallel agents), so expect it to take several minutes.
+
+### Step C — Delegate one pass to resolve-pr-reviews
+
+Read `.claude/commands/resolve-pr-reviews.md` and execute its full flow for PR #{number} **with the `--fix` flag** (fully autonomous — never block on the findings table). It will address comments, run the quality gate, push, run the CI fix loop, and at the end either post `Reviews passed!` (clean path) or re-request both reviewers (if it pushed commits).
+
+### Step D — Decide (machine-checkable, not from prose)
+
+Re-read the head and recount the unresolved comments + CI:
+```
+gh pr view {number} --repo {REPO} --json headRefOid
+gh api --paginate repos/{REPO}/pulls/{number}/comments
+gh pr checks {number} --repo {REPO} --json name,status,conclusion
+```
+Let `head_after` be the new `headRefOid`. If `head_after != head_before`, increment `total_commits_pushed` by the number of new commits.
+
+Classify the pass:
+
+- **Converged** ⇔ `head_after == head_before` **AND** CI green **AND** zero unresolved review comments **AND** both reviews fresh. This is exactly the `resolve-pr-reviews` clean path (it posted `Reviews passed!`). → **STOP — success.**
+- **Progress** ⇔ `head_after != head_before` (the pass pushed fixes; `resolve-pr-reviews` already re-requested both reviewers against the new head). → loop back to **Step A**. Step B will see the pending requests and just wait for the fresh reviews.
+- **Stall** ⇔ `head_after == head_before` **but not converged** (e.g. a finding it classified as a false positive that a reviewer keeps reopening, or something it couldn't fix). Re-running would reproduce an identical state. → **STOP — report.** This is also the infinite-loop guard.
+- **Hard stop** ⇔ `resolve-pr-reviews` stopped unrecoverably (CI `STILL_FAILING` after its 3 attempts, a finding it couldn't classify or fix, or a review trigger that never fired). → **STOP — report.**
+
+---
+
+## Phase 2: Cap
+
+If `MAX_PASSES` passes complete without convergence, **STOP**. Never start a 6th pass.
+
+---
+
+## Phase 3: Final report
+
+Report honestly — do not claim consensus unless the final pass actually converged:
+
+```
+PR #{number}: {title}
+Passes run: {N}/5
+Commits pushed: {total_commits_pushed}
+CI: {PASS|FAIL|PENDING}
+Outcome: {CONVERGED | REVIEW_TIMEOUT | STILL_FAILING | STALL | CAP_REACHED}
+```
+
+In prose: per-pass summary (what each pass fixed / pushed), the final CI status, whether consensus was reached (`Reviews passed!` posted on the final clean pass) or which reviewer / finding / check still blocks it, and the stop reason if it didn't converge. Remind the user that this command **never merges** — that decision belongs to a human.
+
+---
+
+## Rules
+
+- **Never merge.** This command does not merge PRs under any circumstances.
+- **Hard cap of 5 passes.** Never exceed it.
+- **Delegate, don't reimplement.** Only trigger, wait, and decide here. All classification, fixing, replying, and CI repair lives in `resolve-pr-reviews` — run it via `--fix`.
+- **Same freshness rule as `resolve-pr-reviews`.** A review counts only if it postdates the current head commit; stale reviews are treated as missing.
+- **Trigger only at cold start.** Kick off a review only when neither a fresh review nor a pending request exists. After a fix-pushing pass, `resolve-pr-reviews` has already re-requested both — just wait; never double-request across the handoff.
+- **Stop on stall and on hard failure.** Don't waste passes re-running an unchanged, unconverged state.
+- **No `--watch`; poll every ~30s** (backgrounded `sleep 30` re-check or the `Monitor` tool) with a ~15-minute timeout on the wait step.

--- a/.claude/commands/auto-resolve-pr.md
+++ b/.claude/commands/auto-resolve-pr.md
@@ -42,7 +42,7 @@ Repeat for `pass = 1 .. MAX_PASSES`. Announce the pass number at the start of ea
 gh pr view {number} --repo {REPO} --json headRefOid,commits
 ```
 
-Record `headRefOid` (call it `head_before`) and the last commit's `committedDate`. These define "current head" for the freshness checks in Step B and for detecting whether this pass pushed anything in Step D.
+Record `headRefOid` (call it `head_before`), the last commit's `committedDate`, and the commit count (`commit_count_before` = length of the `commits` array). These define "current head" for the freshness checks in Step B, and let Step D detect whether this pass pushed anything and how many commits it added.
 
 ### Step B — Ensure both reviews are fresh + CI complete (the wait)
 
@@ -86,16 +86,18 @@ On the 15-minute timeout, report which reviewer or check never landed and **STOP
 
 Read `.claude/commands/resolve-pr-reviews.md` and execute its full flow for PR #{number} **with the `--fix` flag** (fully autonomous — never block on the findings table). It will address comments, run the quality gate, push, run the CI fix loop, and at the end either post `Reviews passed!` (clean path) or re-request both reviewers (if it pushed commits).
 
+This loop is **hands-off**, so never wait on an interactive prompt: if the delegated CI step (`check-and-fix-ci`) hits its ~10-minute pending timeout and would *"ask the user whether to keep waiting"*, do **not** block — treat it as the delegated pass not settling and **STOP** with outcome `REVIEW_TIMEOUT`, reporting that CI never settled.
+
 ### Step D — Decide (machine-checkable, not from prose)
 
 Re-read the head, CI, and **both** comment surfaces — the `resolve-pr-reviews` clean-path signal, `Reviews passed!`, is an **issue** comment, not a PR review comment, so you must fetch issue comments to detect convergence:
 ```
-gh pr view {number} --repo {REPO} --json headRefOid
+gh pr view {number} --repo {REPO} --json headRefOid,commits
 gh pr checks {number} --repo {REPO} --json name,status,conclusion
 gh api --paginate repos/{REPO}/pulls/{number}/comments     # inline review comments
 gh api --paginate repos/{REPO}/issues/{number}/comments     # incl. any `Reviews passed!` newer than the head
 ```
-Let `head_after` be the new `headRefOid`. If `head_after != head_before`, increment `total_commits_pushed` by the number of new commits.
+Let `head_after` be the new `headRefOid` and `commit_count_after` the new `commits` length. If `head_after != head_before`, increment `total_commits_pushed` by `commit_count_after - commit_count_before` (the commits this pass added).
 
 Classify the pass **in this order — the first match wins**. Hard stop and Stall are checked *before* the head-changed test, because an unrecoverable pass can also have pushed commits (so a naive "head changed → Progress" would loop on a failing pass):
 

--- a/.claude/commands/fix-issue.md
+++ b/.claude/commands/fix-issue.md
@@ -1,7 +1,7 @@
 ---
 description: Fix a GitHub issue (by number/URL) or an ad-hoc problem given as free text — create a branch, research the codebase, plan the fix, implement with tests, commit, push, open a PR, wait for CI and fix any failures, then request Claude and Copilot reviews
 disable-model-invocation: true
-allowed-tools: Bash(gh issue view:*), Bash(gh issue list:*), Bash(gh repo view:*), Bash(gh pr create:*), Bash(gh pr comment:*), Bash(gh pr checks:*), Bash(gh run view:*), Bash(git fetch:*), Bash(git checkout:*), Bash(git status:*), Bash(git branch:*), Bash(git add:*), Bash(git commit:*), Bash(git push:*), Bash(npm ci:*), Bash(npm install:*), Bash(npm i:*), Bash(npm run build:*), Bash(npm run test:*), Bash(npm test:*), Bash(cargo fmt:*), Bash(cargo clippy:*), Bash(cargo test:*), Bash(cargo near:*), Read, Edit, Write, Grep, Glob
+allowed-tools: Bash(gh issue view:*), Bash(gh issue list:*), Bash(gh repo view:*), Bash(gh pr create:*), Bash(gh pr comment:*), Bash(gh pr checks:*), Bash(gh api:*), Bash(gh run view:*), Bash(git fetch:*), Bash(git checkout:*), Bash(git status:*), Bash(git branch:*), Bash(git add:*), Bash(git commit:*), Bash(git push:*), Bash(npm ci:*), Bash(npm install:*), Bash(npm i:*), Bash(npm run build:*), Bash(npm run test:*), Bash(npm test:*), Bash(cargo fmt:*), Bash(cargo clippy:*), Bash(cargo test:*), Bash(cargo near:*), Read, Edit, Write, Grep, Glob
 argument-hint: "<issue-number, issue-url, or a free-text problem description>"
 ---
 

--- a/.claude/commands/fix-issue.md
+++ b/.claude/commands/fix-issue.md
@@ -47,6 +47,7 @@ Create a fresh branch off the latest `main` branch. This project integrates PRs 
 3. Create and switch to a new branch: `git checkout -b fix/{slug} origin/main`
    - **Issue mode:** `{slug}` is `{number}-{short-slug}`, where `{short-slug}` is 3-5 words from the issue title, lowercase, hyphenated (e.g. `fix/42-idor-workspace-check`).
    - **Ad-hoc mode:** `{slug}` is a 3-5 word, lowercase, hyphenated summary of the problem (e.g. `fix/login-redirect-loop`) — no issue number.
+   - **Avoid collisions** (more likely in Ad-hoc mode, which has no issue number): if `fix/{slug}` already exists locally or on the remote — `git rev-parse --verify fix/{slug}` or `git branch -a --list "*fix/{slug}"` finds it — adjust the slug (add a distinguishing word or short suffix) so `git checkout -b` doesn't fail.
 
 If the working tree has uncommitted changes, warn the user and stop. Do not stash or discard their work.
 

--- a/.claude/commands/fix-issue.md
+++ b/.claude/commands/fix-issue.md
@@ -45,8 +45,8 @@ Create a fresh branch off the latest `main` branch. This project integrates PRs 
 1. Fetch latest: `git fetch origin`
 2. Confirm the base branch exists: `git branch -r --list origin/main`. If `origin/main` is not found, stop and tell the user (do not fall back to another branch).
 3. Create and switch to a new branch: `git checkout -b fix/{slug} origin/main`
-   - **Issue mode:** `{slug}` is `{number}-{short-slug}`, where `{short-slug}` is 3-5 words from the issue title, lowercase, hyphenated (e.g. `fix/42-idor-workspace-check`).
-   - **Ad-hoc mode:** `{slug}` is a 3-5 word, lowercase, hyphenated summary of the problem (e.g. `fix/login-redirect-loop`) — no issue number.
+   - **Issue mode:** `{slug}` is `{number}-{short-slug}`, where `{short-slug}` is 3-5 words from the issue title, lowercase, hyphenated — e.g. slug `42-idor-workspace-check` → branch `fix/42-idor-workspace-check`.
+   - **Ad-hoc mode:** `{slug}` is a 3-5 word, lowercase, hyphenated summary of the problem — e.g. slug `login-redirect-loop` → branch `fix/login-redirect-loop` — no issue number.
    - **Avoid collisions** (more likely in Ad-hoc mode, which has no issue number): if `git branch -a --list "*fix/{slug}"` finds `fix/{slug}` already exists locally or on the remote (after the Step 2 `git fetch`), adjust the slug (add a distinguishing word or short suffix) so `git checkout -b` doesn't fail.
 
 If the working tree has uncommitted changes, warn the user and stop. Do not stash or discard their work.

--- a/.claude/commands/fix-issue.md
+++ b/.claude/commands/fix-issue.md
@@ -1,11 +1,11 @@
 ---
-description: Fetch a GitHub issue, create a branch, research the codebase, plan the fix, implement with tests, commit, push, open a PR, wait for CI and fix any failures, then request Claude and Copilot reviews
+description: Fix a GitHub issue (by number/URL) or an ad-hoc problem given as free text — create a branch, research the codebase, plan the fix, implement with tests, commit, push, open a PR, wait for CI and fix any failures, then request Claude and Copilot reviews
 disable-model-invocation: true
-allowed-tools: Bash(gh issue view:*), Bash(gh repo view:*), Bash(gh pr create:*), Bash(gh pr comment:*), Bash(gh pr checks:*), Bash(gh run view:*), Bash(git fetch:*), Bash(git checkout:*), Bash(git status:*), Bash(git branch:*), Bash(git add:*), Bash(git commit:*), Bash(git push:*), Bash(npm ci:*), Bash(npm install:*), Bash(npm i:*), Bash(npm run build:*), Bash(npm run test:*), Bash(npm test:*), Bash(cargo fmt:*), Bash(cargo clippy:*), Bash(cargo test:*), Bash(cargo near:*), Read, Edit, Write, Grep, Glob
-argument-hint: "<issue-number or github-issue-url>"
+allowed-tools: Bash(gh issue view:*), Bash(gh issue list:*), Bash(gh repo view:*), Bash(gh pr create:*), Bash(gh pr comment:*), Bash(gh pr checks:*), Bash(gh run view:*), Bash(git fetch:*), Bash(git checkout:*), Bash(git status:*), Bash(git branch:*), Bash(git add:*), Bash(git commit:*), Bash(git push:*), Bash(npm ci:*), Bash(npm install:*), Bash(npm i:*), Bash(npm run build:*), Bash(npm run test:*), Bash(npm test:*), Bash(cargo fmt:*), Bash(cargo clippy:*), Bash(cargo test:*), Bash(cargo near:*), Read, Edit, Write, Grep, Glob
+argument-hint: "<issue-number, issue-url, or a free-text problem description>"
 ---
 
-# Fix GitHub Issue
+# Fix Issue
 
 ## Step 0: Resolve the target repository
 
@@ -20,20 +20,23 @@ Call it `{REPO}` and use it in every `gh` command below (via `--repo {REPO}`).
 - If the command fails (not a git repository, or no GitHub remote), stop and ask the user for the repository.
 - All `git` operations (fetch, branch, checkout, commit) run inside this working copy.
 
-## Step 1: Resolve the issue
+## Step 1: Resolve the input
 
-Parse `$ARGUMENTS` to extract the issue number:
-- If it's a URL like `https://github.com/owner/repo/issues/42`, extract `42`.
-- If it's a bare number, use it directly.
-- If empty, stop and ask the user for an issue number.
+`$ARGUMENTS` is either a GitHub issue reference or a free-text problem description. Decide which:
 
-Fetch the issue:
+- **Issue mode** — `$ARGUMENTS` is a bare number (e.g. `42`) or a GitHub issue URL (e.g. `https://github.com/owner/repo/issues/42`). Extract the number and fetch the issue:
 
-```
-gh issue view {number} --repo {REPO} --json title,body,labels,assignees,comments,state
-```
+  ```
+  gh issue view {number} --repo {REPO} --json title,body,labels,assignees,comments,state
+  ```
 
-If the issue is closed, warn the user and ask if they still want to proceed.
+  If the issue is closed, warn the user and ask if they still want to proceed. The issue title + body is the **problem statement**.
+
+- **Ad-hoc mode** — anything else is a free-text problem description (e.g. `there is a problem with xyz, lets fix it`). There is no GitHub issue; the text itself is the **problem statement**. Do not run `gh issue view`. Optionally run `gh issue list --repo {REPO} --search "<keywords>"` to check whether an issue already tracks this — if an obvious match exists, mention it and ask whether to proceed against that issue (Issue mode) instead.
+
+- **Empty** — if `$ARGUMENTS` is blank, stop and ask the user for an issue number or a problem description.
+
+Carry forward the **problem statement** (and, in Issue mode, the issue **number**) — later steps refer to both.
 
 ## Step 2: Create a branch
 
@@ -41,26 +44,27 @@ Create a fresh branch off the latest `main` branch. This project integrates PRs 
 
 1. Fetch latest: `git fetch origin`
 2. Confirm the base branch exists: `git branch -r --list origin/main`. If `origin/main` is not found, stop and tell the user (do not fall back to another branch).
-3. Create and switch to a new branch: `git checkout -b fix/{number}-{short-slug} origin/main`
-   - `{short-slug}` is 3-5 words from the issue title, lowercase, hyphenated (e.g. `fix/42-idor-workspace-check`)
+3. Create and switch to a new branch: `git checkout -b fix/{slug} origin/main`
+   - **Issue mode:** `{slug}` is `{number}-{short-slug}`, where `{short-slug}` is 3-5 words from the issue title, lowercase, hyphenated (e.g. `fix/42-idor-workspace-check`).
+   - **Ad-hoc mode:** `{slug}` is a 3-5 word, lowercase, hyphenated summary of the problem (e.g. `fix/login-redirect-loop`) — no issue number.
 
 If the working tree has uncommitted changes, warn the user and stop. Do not stash or discard their work.
 
-## Step 3: Understand the issue
+## Step 3: Understand the problem
 
-Summarize the issue in 2-3 sentences. Identify:
+Summarize the problem in 2-3 sentences. Identify:
 - **What's broken or missing** (the symptom or feature request)
-- **Acceptance criteria** (what "done" looks like, from the issue body or comments)
+- **Acceptance criteria** (what "done" looks like — from the issue body/comments in Issue mode, or inferred from the description in Ad-hoc mode)
 - **Constraints** (mentioned technologies, backward compatibility, performance requirements)
 
-If the issue is unclear or ambiguous, list the open questions. These will be addressed during planning.
+If the problem is unclear or ambiguous, list the open questions and ask the user before planning — especially in Ad-hoc mode, where there's no issue body to fall back on, so confirm anything material that the free-text description left undefined.
 
 ## Step 4: Research the codebase
 
 Before planning, gather context:
 
-1. **Find relevant code** - Search for files, functions, types, and patterns mentioned in the issue. Read them in full.
-2. **Trace the flow** - If the issue is about a specific behavior, trace the code path from the entry point (route handler, CLI command, etc.) through to the relevant logic.
+1. **Find relevant code** - Search for files, functions, types, and patterns named in the problem statement. Read them in full.
+2. **Trace the flow** - If the problem is about a specific behavior, trace the code path from the entry point (route handler, CLI command, etc.) through to the relevant logic.
 3. **Check existing tests** - Find tests related to the affected code. Understand what's already covered.
 4. **Check for prior art** - Look for similar patterns in the codebase that solve analogous problems. Prefer consistency with existing patterns.
 5. **Load CLAUDE.md guidance** - Find and read the root CLAUDE.md and every CLAUDE.md in directories containing files you expect to touch (use Glob to find them). Their rules are binding on the plan.
@@ -97,8 +101,8 @@ After the plan is approved:
 
 ## Step 7: Commit, push, and open a PR
 
-1. Commit following `.claude/project-specifics/commit-conventions.md` — read it and pick the type and scope from its lists. Reference the issue in the description (e.g. `fix(api): prevent idor in function call outputs (#42)`).
-2. Push the branch: `git push -u origin HEAD` (this pushes only the `fix/{number}-{short-slug}` branch — never push to the integration branch directly).
+1. Commit following `.claude/project-specifics/commit-conventions.md` — read it and pick the type and scope from its lists. In **Issue mode**, reference the issue in the description (e.g. `fix(api): prevent idor in function call outputs (#42)`); in **Ad-hoc mode** there is no issue, so omit the `(#N)` reference.
+2. Push the branch: `git push -u origin HEAD` (this pushes only the `fix/{slug}` branch — never push to the integration branch directly).
 3. Open a PR into `main` with the summary as its description:
 
    ```
@@ -106,7 +110,7 @@ After the plan is approved:
    ```
 
    - **Title**: the commit-conventions format, same type/scope as the commit (e.g. `fix(api): prevent idor in function call outputs`).
-   - **Body**: start with `Closes #{number}`, then:
+   - **Body**: open with — **Issue mode:** `Closes #{number}`; **Ad-hoc mode:** a one-line statement of the problem being fixed (there's no issue to close). Then, in both modes:
      - What changed and why (2-4 sentences, root cause for bugs)
      - Files changed with brief per-file notes
      - Tests added and what they cover
@@ -138,4 +142,4 @@ Read `.claude/commands/utils/check-and-fix-ci.md` and follow it for PR #{pr-numb
 
    This needs the repo/author to have Copilot code-review access and available premium-request quota; if the request errors or Copilot never posts, note it in the recap rather than retrying.
 
-3. Report back in chat: the PR URL, the CI outcome, whether the Claude review comment was posted, whether the Copilot review was requested, and a short recap of the change, tests, and open questions. Remind the user: once the reviews land, continue with `/resolve-pr-reviews {pr-number}`.
+3. Report back in chat: the PR URL, the CI outcome, whether the Claude review comment was posted, whether the Copilot review was requested, and a short recap of the change, tests, and open questions. Remind the user: once the reviews land, continue with `/resolve-pr-reviews {pr-number}` — or run `/auto-resolve-pr {pr-number}` to drive that review→fix loop hands-off to consensus.

--- a/.claude/commands/fix-issue.md
+++ b/.claude/commands/fix-issue.md
@@ -47,7 +47,7 @@ Create a fresh branch off the latest `main` branch. This project integrates PRs 
 3. Create and switch to a new branch: `git checkout -b fix/{slug} origin/main`
    - **Issue mode:** `{slug}` is `{number}-{short-slug}`, where `{short-slug}` is 3-5 words from the issue title, lowercase, hyphenated (e.g. `fix/42-idor-workspace-check`).
    - **Ad-hoc mode:** `{slug}` is a 3-5 word, lowercase, hyphenated summary of the problem (e.g. `fix/login-redirect-loop`) — no issue number.
-   - **Avoid collisions** (more likely in Ad-hoc mode, which has no issue number): if `fix/{slug}` already exists locally or on the remote — `git rev-parse --verify fix/{slug}` or `git branch -a --list "*fix/{slug}"` finds it — adjust the slug (add a distinguishing word or short suffix) so `git checkout -b` doesn't fail.
+   - **Avoid collisions** (more likely in Ad-hoc mode, which has no issue number): if `git branch -a --list "*fix/{slug}"` finds `fix/{slug}` already exists locally or on the remote (after the Step 2 `git fetch`), adjust the slug (add a distinguishing word or short suffix) so `git checkout -b` doesn't fail.
 
 If the working tree has uncommitted changes, warn the user and stop. Do not stash or discard their work.
 

--- a/.claude/commands/fix-issue.md
+++ b/.claude/commands/fix-issue.md
@@ -32,7 +32,7 @@ Call it `{REPO}` and use it in every `gh` command below (via `--repo {REPO}`).
 
   If the issue is closed, warn the user and ask if they still want to proceed. The issue title + body is the **problem statement**.
 
-- **Ad-hoc mode** — anything else is a free-text problem description (e.g. `there is a problem with xyz, lets fix it`). There is no GitHub issue; the text itself is the **problem statement**. Do not run `gh issue view`. Optionally run `gh issue list --repo {REPO} --search "<keywords>"` to check whether an issue already tracks this — if an obvious match exists, mention it and ask whether to proceed against that issue (Issue mode) instead.
+- **Ad-hoc mode** — anything else is a free-text problem description (e.g. `there is a problem with xyz, let's fix it`). There is no GitHub issue; the text itself is the **problem statement**. Do not run `gh issue view`. Optionally run `gh issue list --repo {REPO} --search "<keywords>"` to check whether an issue already tracks this — if an obvious match exists, mention it and ask whether to proceed against that issue (Issue mode) instead.
 
 - **Empty** — if `$ARGUMENTS` is blank, stop and ask the user for an issue number or a problem description.
 


### PR DESCRIPTION
## What & why

`/fix-issue` only accepted a GitHub issue number/URL. This lets it **also take a free-text problem description**, so you can say e.g. `/fix-issue there is a problem with xyz, lets fix it` and go straight to a branch → plan → fix → PR without first filing an issue.

## Changes

**`.claude/commands/fix-issue.md`** — now has two modes:
- **Issue mode** (unchanged): a bare number or issue URL → `gh issue view`, branch `fix/{number}-{slug}`, commit references `(#N)`, PR body opens with `Closes #{number}`.
- **Ad-hoc mode** (new): any other text is the problem statement → no issue fetch, branch `fix/{slug}` from the description, commit omits the `(#N)` ref, PR body opens with a one-line statement of the problem (no `Closes`). Step 3 explicitly asks the user to confirm anything material the free-text left undefined (no issue body to fall back on). Optionally checks `gh issue list` for an existing matching issue.
- Frontmatter (`description`, `argument-hint`), title (`Fix Issue`), and the Step 4 research wording generalized; `gh issue list` and `gh api` added to allowed-tools (the latter also fixes a pre-existing dead grant — Step 9's Copilot request already used `gh api`).

**`.claude/commands/auto-resolve-pr.md`** (new) — the hands-off review→fix loop command (waits for fresh Claude+Copilot reviews + CI, runs `/resolve-pr-reviews --fix`, repeats up to 5 passes, never merges). It was developed locally and is referenced from `fix-issue.md` Step 9, so it's committed here so the reference resolves.

## Release impact

No release impact — command tooling only, no published package touched.
