### PR TITLE
ci: automate releases with release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -25,13 +25,18 @@ jobs:
       attestation_released: ${{ steps.rp.outputs['shade-attestation--release_created'] }}
       attestation_tag: ${{ steps.rp.outputs['shade-attestation--tag_name'] }}
     steps:
-      # Uses RELEASE_PLEASE_TOKEN (a PAT / App token), not the default
+      # Mint a short-lived token from the release GitHub App, not the default
       # GITHUB_TOKEN: PRs opened by GITHUB_TOKEN don't trigger ci.yml, so the
       # required ci-passed check would never run on the release PR.
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        id: app-token
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
       - uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4.4.1
         id: rp
         with:
-          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,105 @@
+name: Release Please
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-please-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    outputs:
+      js_released: ${{ steps.rp.outputs['shade-agent-js--release_created'] }}
+      js_tag: ${{ steps.rp.outputs['shade-agent-js--tag_name'] }}
+      cli_released: ${{ steps.rp.outputs['shade-agent-cli--release_created'] }}
+      cli_tag: ${{ steps.rp.outputs['shade-agent-cli--tag_name'] }}
+      attestation_released: ${{ steps.rp.outputs['shade-attestation--release_created'] }}
+      attestation_tag: ${{ steps.rp.outputs['shade-attestation--tag_name'] }}
+    steps:
+      # Uses RELEASE_PLEASE_TOKEN (a PAT / App token), not the default
+      # GITHUB_TOKEN: PRs opened by GITHUB_TOKEN don't trigger ci.yml, so the
+      # required ci-passed check would never run on the release PR.
+      - uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4.4.1
+        id: rp
+        with:
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          config-file: release-please-config.json
+          manifest-file: .release-please-manifest.json
+
+  publish-shade-agent-js:
+    needs: release-please
+    if: needs.release-please.outputs.js_released == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # npm OIDC trusted publishing + provenance
+    defaults:
+      run:
+        working-directory: shade-agent-js
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          ref: ${{ needs.release-please.outputs.js_tag }}
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 22
+          registry-url: https://registry.npmjs.org
+          cache: npm
+          cache-dependency-path: shade-agent-js/package-lock.json
+      - run: npm install -g npm@latest # OIDC trusted publishing needs npm >= 11.5.1
+      - run: npm ci
+      - run: npm publish --access public
+
+  publish-shade-agent-cli:
+    needs: release-please
+    if: needs.release-please.outputs.cli_released == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    defaults:
+      run:
+        working-directory: shade-agent-cli
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          ref: ${{ needs.release-please.outputs.cli_tag }}
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 22
+          registry-url: https://registry.npmjs.org
+          cache: npm
+          cache-dependency-path: shade-agent-cli/package-lock.json
+      - run: npm install -g npm@latest
+      - run: npm ci
+      - run: npm publish --access public
+
+  publish-shade-attestation:
+    needs: release-please
+    if: needs.release-please.outputs.attestation_released == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # crates.io OIDC trusted publishing
+    defaults:
+      run:
+        working-directory: shade-attestation
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          ref: ${{ needs.release-please.outputs.attestation_tag }}
+      - run: rustup show # installs the toolchain pinned in rust-toolchain.toml
+      - uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 # v1.0.5
+        id: auth
+      - run: cargo publish --locked
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,0 +1,5 @@
+{
+  "shade-agent-js": "2.2.0",
+  "shade-agent-cli": "2.4.0",
+  "shade-attestation": "0.2.0"
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,9 +36,13 @@ Changes to a package are not done until every downstream artefact has been updat
 
 ## Versioning and releases
 
-**Never bump a package version in a PR into `main`.** Version bumps for the published packages (`@neardefi/shade-agent-js`, `@neardefi/shade-agent-cli`, the `shade-attestation` crate) are handled separately once changes are on `main`, via dedicated `chore(release): <package>-vX.Y.Z` commits. Leave `package.json` / `Cargo.toml` versions untouched in feature, fix, and chore PRs.
+Releases are automated by **release-please** (`.github/workflows/release-please.yml`, config in `release-please-config.json`). It reads [Conventional Commits](https://www.conventionalcommits.org/) on `main` and keeps a per-package release PR (`chore(release): <package>-vX.Y.Z`) open that bumps the version + lockfile and writes the package's `CHANGELOG.md`; merging that PR tags the release and publishes `@neardefi/shade-agent-js`, `@neardefi/shade-agent-cli`, and the `shade-attestation` crate via CI.
 
-**State the release impact in the PR description.** When a PR changes a published package's behaviour or public surface, the PR description must say which package(s) it affects and whether it will need a **major**, **minor**, or **patch** bump when released — unless the description already says so. Use semver: **major** = a breaking change to the public API or to behaviour consumers depend on; **minor** = backward-compatible new behaviour or feature; **patch** = backward-compatible fix. A PR that touches no published package can say "no release impact".
+**Never bump a package version or write a `chore(release)` commit by hand.** Leave `package.json` / `Cargo.toml` versions untouched in feature, fix, and chore PRs — the release PR owns them.
+
+**The commit type drives the bump, so write it accurately.** `fix:` → patch, `feat:` → minor, `feat!:` or a `BREAKING CHANGE:` footer → major. `shade-attestation` is pre-1.0, so its breaking changes bump the minor (`0.x.0`). Commits scope to a package by the file path they touch. A PR of only `chore` / `docs` / `refactor` / `test` / `ci` commits produces no release. To pin an exact next version, add a `Release-As: X.Y.Z` footer to a commit.
+
+**State the release impact in the PR description.** When a PR changes a published package's behaviour or public surface, say which package(s) it affects and whether it's a **major**, **minor**, or **patch** — this is what reviewers check the commit types against. Use semver: **major** = a breaking change to the public API or to behaviour consumers depend on; **minor** = backward-compatible new behaviour or feature; **patch** = backward-compatible fix. A PR that touches no published package can say "no release impact".
 
 ## Tests
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "separate-pull-requests": true,
+  "include-component-in-tag": true,
+  "pull-request-title-pattern": "chore(release): ${component}-v${version}",
+  "packages": {
+    "shade-agent-js": {
+      "release-type": "node",
+      "component": "shade-agent-js",
+      "package-name": "@neardefi/shade-agent-js"
+    },
+    "shade-agent-cli": {
+      "release-type": "node",
+      "component": "shade-agent-cli",
+      "package-name": "@neardefi/shade-agent-cli"
+    },
+    "shade-attestation": {
+      "release-type": "rust",
+      "component": "shade-attestation",
+      "package-name": "shade-attestation",
+      "bump-minor-pre-major": true
+    }
+  }
+}


### PR DESCRIPTION
## What this does

Automates versioning, changelogs, and publishing for the three published packages with **release-please** — one manifest-driven tool covering both ecosystems:

| Package | release-type | Publishes to |
| --- | --- | --- |
| `shade-agent-js` (`@neardefi/shade-agent-js`) | `node` | npm |
| `shade-agent-cli` (`@neardefi/shade-agent-cli`) | `node` | npm |
| `shade-attestation` | `rust` | crates.io |

release-please reads Conventional Commits on `main` and keeps a **per-package release PR** (`chore(release): <pkg>-vX.Y.Z`) open that bumps the version + lockfile and writes a `CHANGELOG.md`. Merging that PR creates the tag + GitHub Release, which triggers the publish job for that package.

This mirrors the [release-plz](https://github.com/release-plz/release-plz) "release-PR then publish-on-merge" model used by `near-sdk-rs`, but covers npm **and** Rust in one tool, and reproduces our existing `<pkg>-v<semver>` tags and `chore(release):` commit convention.

### Files

- `release-please-config.json` — per-package config; `bump-minor-pre-major` set for the pre-1.0 crate; tags as `<component>-v<version>` (matches history exactly).
- `.release-please-manifest.json` — seeded at current versions (2.2.0 / 2.4.0 / 0.2.0); existing tags anchor "last release", so no backfill.
- `.github/workflows/release-please.yml` — release-please job + three OIDC publish jobs gated on per-package outputs.
- `CLAUDE.md` — rewrote "Versioning and releases" for the automated flow.

Publishing uses **OIDC trusted publishing** (no long-lived tokens; npm gets provenance automatically; crates.io via `crates-io-auth-action`). All actions SHA-pinned per repo convention.

## ⚠️ Manual setup required before the first release

1. **Create a release GitHub App and add its credentials as secrets.** Create an org-owned GitHub App with repository permissions **Contents: R/W** + **Pull requests: R/W**, install it on this repo, then store its App ID as `RELEASE_APP_ID` and a generated private key as `RELEASE_APP_PRIVATE_KEY` (Settings → Secrets and variables → Actions). The workflow mints a short-lived token from it via `actions/create-github-app-token`. Required because PRs opened by the default `GITHUB_TOKEN` do **not** trigger `ci.yml`, so the required `ci-passed` check would never run on the release PR. (A fine-grained PAT with the same two permissions also works if you'd rather not set up an App — swap the token step for `token: ${{ secrets.RELEASE_PLEASE_TOKEN }}`.)
2. **npm trusted publishing** — on npmjs.com, for **both** `@neardefi/shade-agent-js` and `@neardefi/shade-agent-cli`: package Settings → Trusted Publisher → add GitHub Actions: repo `NearDeFi/shade-agent-framework`, workflow `release-please.yml`. (Needs org publish rights.)
3. **crates.io trusted publishing** — on crates.io, `shade-attestation` → Settings → Trusted Publishing → add repo `NearDeFi/shade-agent-framework`, workflow `release-please.yml`.
4. **Merge method** — ensure **squash-merge** is enabled so the merged release commit reads `chore(release): <pkg>-vX.Y.Z (#N)`, matching history.

_Token fallback (if you skip OIDC):_ add `NPM_TOKEN` + `CARGO_REGISTRY_TOKEN` secrets and wire `NODE_AUTH_TOKEN` / `CARGO_REGISTRY_TOKEN` into the publish steps. OIDC is recommended.

## Verifying the first run

After merge, the next push to `main` opens the first release PR(s). Confirm: tags are `<pkg>-vX.Y.Z`; PR title is `chore(release): <pkg>-vX.Y.Z`; the diff touches `package.json`+`package-lock.json` / `Cargo.toml`+`Cargo.lock` plus a new `CHANGELOG.md`; and `ci-passed` runs on the PR (proves the App token works). If release-please proposes releasing from scratch instead of anchoring to existing tags, add a `bootstrap-sha` / `last-release-sha` and re-run.

## Notes / caveats

- **Cross-repo pin (manual):** `template/agent-contract` lives in a separate (gitignored) checkout and pins `shade-attestation = "=X.Y.Z"`. After a crate release + crates.io propagation, bump that pin there by hand — it can't be automated from this repo. The only in-repo consumer, `shade-contract-template`, uses a path dep and needs no bump.
- `min-release-age=7d` in `.npmrc` only affects installs, not publishing — no interaction.
- `cargo publish --locked` runs a host verification build; if the crate's wasm-only `getrandom` handler ever breaks host verification, add `--no-verify`.

## Release impact

No release impact — CI + docs only; no published package's code or public surface changes.
