### PR TITLE
chore: weekly grouped dependabot with cooldown + CI merge queue

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,49 +4,134 @@ updates:
   - package-ecosystem: npm
     directory: /shade-agent-cli
     schedule:
-      interval: monthly
+      interval: weekly
     versioning-strategy: increase
     open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7
     groups:
-      dev-dependencies:
-        dependency-type: development
+      patch:
+        patterns:
+          - "*"
+        update-types:
+          - "patch"
+      minor:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
 
   - package-ecosystem: npm
     directory: /shade-agent-js
     schedule:
-      interval: monthly
+      interval: weekly
     versioning-strategy: increase
     open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7
     groups:
-      dev-dependencies:
-        dependency-type: development
+      patch:
+        patterns:
+          - "*"
+        update-types:
+          - "patch"
+      minor:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
 
   - package-ecosystem: npm
     directory: /shade-agent-template
     schedule:
-      interval: monthly
+      interval: weekly
     versioning-strategy: increase
     open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7
+    groups:
+      patch:
+        patterns:
+          - "*"
+        update-types:
+          - "patch"
+      minor:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
 
   # Rust crates
   - package-ecosystem: cargo
     directory: /shade-attestation
     schedule:
-      interval: monthly
+      interval: weekly
     open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7
+    groups:
+      patch:
+        patterns:
+          - "*"
+        update-types:
+          - "patch"
+      minor:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
 
   - package-ecosystem: cargo
     directory: /shade-contract-template
     schedule:
-      interval: monthly
+      interval: weekly
     open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7
+    groups:
+      patch:
+        patterns:
+          - "*"
+        update-types:
+          - "patch"
+      minor:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
 
   - package-ecosystem: docker
     directory: /
     schedule:
-      interval: monthly
+      interval: weekly
+    cooldown:
+      default-days: 7
+    groups:
+      patch:
+        patterns:
+          - "*"
+        update-types:
+          - "patch"
+      minor:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
 
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: monthly
+      interval: weekly
+    cooldown:
+      default-days: 7
+    groups:
+      patch:
+        patterns:
+          - "*"
+        update-types:
+          - "patch"
+      minor:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,8 @@ on:
     branches: [main, stable]
   push:
     branches: [main]
+  # Re-run against the merge queue's combined branch before it lands on main.
+  merge_group:
 
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
@@ -18,7 +20,8 @@ permissions:
 
 jobs:
   # Detect which areas changed so we only run the relevant jobs. The `all`
-  # filter (CI config / toolchain) forces every job to run.
+  # filter (CI config / toolchain) forces every job to run, as does a
+  # merge_group event — the queue validates the full suite before landing.
   changes:
     runs-on: ubuntu-latest
     outputs:
@@ -27,10 +30,11 @@ jobs:
       js_tmpl: ${{ steps.filter.outputs.js_tmpl }}
       attestation: ${{ steps.filter.outputs.attestation }}
       contract: ${{ steps.filter.outputs.contract }}
-      all: ${{ steps.filter.outputs.all }}
+      all: ${{ steps.filter.outputs.all == 'true' || github.event_name == 'merge_group' }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3.0.3
+        if: github.event_name != 'merge_group'
         id: filter
         with:
           filters: |


### PR DESCRIPTION
## What

Tunes how Dependabot proposes updates and adds a merge queue so dependency PRs land safely with less noise.

### `.github/dependabot.yml`
- **Weekly** instead of monthly, for every ecosystem.
- **7-day `cooldown`** on every ecosystem — Dependabot waits a week after a release before opening the version-update PR, so freshly-published bad/compromised releases get a chance to be yanked first. (Security updates intentionally bypass cooldown.)
- **Grouping**: one PR for **all patch** updates, one PR for **all minor** updates, and **majors stay individual** (they fall through to their own PRs). Fewer PRs ⇒ fewer overlapping lockfile edits ⇒ far fewer conflicts. This replaces the previous partial `dev-dependencies` grouping.

### `.github/workflows/ci.yml`
- Adds the **`merge_group`** trigger so CI re-runs against the merge queue's combined branch (`latest main` + the PRs ahead in the queue) before a PR lands — catching "green in isolation, broken once merged" semantic conflicts.
- On `merge_group` events the path-filter is skipped and the **full suite runs** (the queue is the last gate before main).

## Release impact

No release impact — CI / Dependabot config only; no published package code or public surface changed.

## Manual follow-ups (cannot live in a PR — repo settings)

1. **Turn on vulnerability PRs** (Dependabot security updates): Settings → Code security → enable **Dependabot alerts** + **Dependabot security updates**.
2. **Enable the merge queue + required check on `main`**: Settings → Rules/Branches → require the **merge queue** and require the **`ci-passed`** status check. Without this, `merge_group` never fires and the queue does nothing.
