### PR TITLE
ci: pin npm version in release publish jobs

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -60,7 +60,7 @@ jobs:
           registry-url: https://registry.npmjs.org
           cache: npm
           cache-dependency-path: shade-agent-js/package-lock.json
-      - run: npm install -g npm@latest # OIDC trusted publishing needs npm >= 11.5.1
+      - run: npm install -g npm@11.17.0 # OIDC trusted publishing needs npm >= 11.5.1; pin, bump deliberately
       - run: npm ci
       - run: npm publish --access public
 
@@ -84,7 +84,7 @@ jobs:
           registry-url: https://registry.npmjs.org
           cache: npm
           cache-dependency-path: shade-agent-cli/package-lock.json
-      - run: npm install -g npm@latest
+      - run: npm install -g npm@11.17.0
       - run: npm ci
       - run: npm publish --access public
 
@@ -102,7 +102,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: ${{ needs.release-please.outputs.attestation_tag }}
-      - run: rustup show # installs the toolchain pinned in rust-toolchain.toml
+      - run: rustup show # selects the rust-toolchain.toml toolchain (cargo installs it on first use)
       - uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 # v1.0.5
         id: auth
       - run: cargo publish --locked


### PR DESCRIPTION
Follow-up to #106 addressing the Copilot review comments on the release workflow.

## Changes

- **Pin npm in both publish jobs** — `npm install -g npm@latest` → `npm install -g npm@11.17.0`. `@latest` made the publish pipeline non-reproducible and could break on a surprise npm release with no repo change. Pinned to a current known-good version (newer than the 11.5.1 OIDC floor, so we keep early-OIDC fixes); bump deliberately when needed.
- **Fix the `rustup show` comment** — it implied the command installs the pinned toolchain. Reworded to reflect that it selects the `rust-toolchain.toml` toolchain and `cargo` installs it on first use. (`ci.yml` uses the same `rustup show` idiom; left untouched here.)

No behavioural change beyond the npm version pin.

## Release impact

No release impact — CI only.
