### PR TITLE
fix: drop npm min-release-age from .npmrc (breaks Dependabot lockfile updates)

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,1 @@
 save-exact=true
-min-release-age=7d


### PR DESCRIPTION
## Problem

Every npm Dependabot job has been failing with `dependency_file_not_resolvable` ("Error while updating peer dependency", then a cascade of `unknown_error` for the rest), e.g. job `1428396258` on `shade-agent-cli`. No PRs could be opened/rebased for any npm package.

## Root cause

The root `.npmrc` carries `min-release-age=7d` (added in #31, 2026-04-30). That npm config was introduced in **npm v11.10.0** and is **not honored by npm ≤ 10** (our CI/local runs npm 10.9.4 — `npm config get min-release-age` → `undefined`), so it's a no-op for us. But **Dependabot's updater runs a newer npm that does honor it**: it reads the `.npmrc`, then can't reconcile "install the exact freshly-bumped version" with "refuse anything younger than 7 days", and aborts lockfile regeneration → `dependency_file_not_resolvable`. The grouped update fails atomically, marking every updatable dependency as failed.

This is a known, open Dependabot incompatibility:
- dependabot/dependabot-core#15112 — *npm's `min-release-age` prevents Dependabot from making PRs*
- dependabot/dependabot-core#14151 — *convert npm `min-release-age` to equivalent Cooldown options*

## Fix

Remove `min-release-age=7d` from `.npmrc`. The 7-day age requirement is already enforced for Dependabot's automated PRs by `cooldown: default-days: 7` in `dependabot.yml` (added in #107) — the layer Dependabot actually supports — so this is not a loss of protection, just moving it to where it works. `save-exact=true` is kept.

No effect on `npm ci` (installs the committed lockfile verbatim; `min-release-age` only applies to resolution) and no change to any committed lockfile.

## Release impact

No release impact — repo tooling config only; `.npmrc` is not published with any package.
