### PR TITLE
chore: raise npm dependabot cooldown to 10 days (clears .npmrc min-release-age)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,7 @@
 version: 2
 updates:
-  # npm packages
+  # npm packages — cooldown is set above the .npmrc min-release-age (7d) so
+  # Dependabot only ever proposes versions npm will actually resolve.
   - package-ecosystem: npm
     directory: /shade-agent-cli
     schedule:
@@ -8,7 +9,7 @@ updates:
     versioning-strategy: increase
     open-pull-requests-limit: 5
     cooldown:
-      default-days: 7
+      default-days: 10
     groups:
       patch:
         patterns:
@@ -28,7 +29,7 @@ updates:
     versioning-strategy: increase
     open-pull-requests-limit: 5
     cooldown:
-      default-days: 7
+      default-days: 10
     groups:
       patch:
         patterns:
@@ -48,7 +49,7 @@ updates:
     versioning-strategy: increase
     open-pull-requests-limit: 5
     cooldown:
-      default-days: 7
+      default-days: 10
     groups:
       patch:
         patterns:


### PR DESCRIPTION
## What

Raise the **npm** Dependabot `cooldown` from 7 → **10 days**. Cargo/docker/github-actions stay at 7.

## Why

The root `.npmrc` sets `min-release-age=7d`, so npm refuses to *resolve* any version younger than 7 days. Dependabot regenerates the lockfile by running `npm install`, which honors that floor.

With the Dependabot `cooldown` also at 7 days, the two gates sit on the same line: a version right at ~7 days old passes Dependabot's "≥7d" check (evaluated when it opens the PR) but can be rejected by npm's `now − 7d` cutoff (evaluated to-the-second later, during lockfile regeneration) → `dependency_file_not_resolvable`, and the whole grouped update fails.

Setting the npm cooldown to **10 days** gives a 3-day margin, so every version Dependabot proposes is comfortably past npm's 7-day floor and resolves cleanly. The non-npm ecosystems don't read `.npmrc`, so they have no floor to clear and keep `cooldown: 7`.

## Release impact

No release impact — Dependabot config only.
