### PR TITLE
fix: correct .npmrc min-release-age value (7d -> 7)

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,2 @@
 save-exact=true
-min-release-age=7d
+min-release-age=7


### PR DESCRIPTION
## What

Fix the `min-release-age` value in `.npmrc` from `7d` → `7`.

## Why

npm's `min-release-age` config takes a **plain number of days**, not a duration string. `7d` is rejected:

```
npm warn invalid config min-release-age="7d"
npm warn invalid config Must be one of: null, numeric value
npm error Invalid time value
```

npm ≤10 silently ignores the unknown key (so local/CI never saw it), but Dependabot runs npm 11.17, which honors it — and the malformed `7d` value makes npm abort every lockfile regeneration, failing all npm dependency updates. `min-release-age=7` is the correct form (7 days).

Together with the 10-day Dependabot cooldown (already in `dependabot.yml`), this keeps the 7-day minimum-release-age policy enforced while letting Dependabot regenerate lockfiles cleanly.

## Release impact

No release impact — repo tooling config only.
