### PR TITLE
test: make tests-in-tee safe to run concurrently

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -205,6 +205,20 @@ jobs:
           else
             echo "No .cvm-id file; nothing to tear down."
           fi
+      # Backstop for the per-run contract account (deleting it needs a signed
+      # NEAR tx, so it goes through teardown-account.js rather than curl).
+      - name: Tear down leftover contract account
+        if: always()
+        working-directory: tests-in-tee
+        env:
+          TESTNET_ACCOUNT_ID: ${{ secrets.TESTNET_ACCOUNT_ID }}
+          TESTNET_PRIVATE_KEY: ${{ secrets.TESTNET_PRIVATE_KEY }}
+        run: |
+          if [ -f .contract-id ]; then
+            node teardown-account.js "$(cat .contract-id)" || true
+          else
+            echo "No .contract-id file; nothing to tear down."
+          fi
 
   # Post the final (informational) e2e status on the PR head commit.
   report:

--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@ target/
 dist/
 build/
 license-generator/
-# Transient CVM id written by tests-in-tee for teardown
+# Transient ids written by tests-in-tee for teardown
 .cvm-id
+.contract-id

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ cargo add shade-attestation
   PHALA_API_KEY=
   ```
 
-  TESTNET and SPONSOR can be the same; make sure the account has at least 20 testnet NEAR.
+  TESTNET and SPONSOR can be the same; make sure the account has at least 20 testnet NEAR. The tests-in-tee suite funds a per-run contract account with ~10 NEAR (refunded on teardown), so budget ~10 more per concurrent run.
 
 - Run all tests
 

--- a/tests-in-tee/README.md
+++ b/tests-in-tee/README.md
@@ -69,7 +69,7 @@ Integration tests that run inside a TEE (Phala). They test shade-agent-js, shade
 
 Each run uses a random per-run slug for the contract account
 (`shade-test-<slug>.<account>`) and the Phala app name, so independent runs
-(e.g. on different PRs) never collide.
+(e.g. on different PRs) are extremely unlikely to collide.
 
 `test-script.js` always tears down what it provisions when the run finishes — on
 success **or** failure — so a failed run no longer leaves a paid TEE instance or

--- a/tests-in-tee/README.md
+++ b/tests-in-tee/README.md
@@ -69,10 +69,10 @@ Integration tests that run inside a TEE (Phala). They test shade-agent-js, shade
 
 Each run uses a random per-run slug for the contract account
 (`shade-test-<slug>.<account>`) and the Phala app name, so independent runs
-(e.g. on different PRs) are extremely unlikely to collide.
+(e.g. on different PRs) don't collide.
 
 `test-script.js` always tears down what it provisions when the run finishes — on
-success **or** failure — so a failed run no longer leaves a paid TEE instance or
+success **or** failure — so a failed run doesn't leave a paid TEE instance or
 a funded account behind: the Phala CVM is deleted, and the per-run contract
 account is deleted with its balance refunded to the parent. Both ids are written
 to `tests-in-tee/.cvm-id` and `tests-in-tee/.contract-id` so CI can clean them up

--- a/tests-in-tee/README.md
+++ b/tests-in-tee/README.md
@@ -54,7 +54,7 @@ Integration tests that run inside a TEE (Phala). They test shade-agent-js, shade
   PHALA_API_KEY=
   ```
 
-  TESTNET and SPONSOR can be the same; make sure the account has at least 20 testnet NEAR.
+  TESTNET and SPONSOR can be the same; make sure the account has at least 20 testnet NEAR. Each run funds its own per-run contract account with ~10 NEAR (refunded on teardown), so budget ~10 more per concurrent run.
 
 - Run the tests
 
@@ -67,10 +67,17 @@ Integration tests that run inside a TEE (Phala). They test shade-agent-js, shade
 
 ## Cleanup
 
-`test-script.js` always tears down the Phala CVM it provisions when the run
-finishes — on success **or** failure — so a failed run no longer leaves a paid
-TEE instance running. The CVM id is also written to `tests-in-tee/.cvm-id` so
-CI can delete it as a backstop if the process is killed before cleanup runs.
+Each run uses a random per-run slug for the contract account
+(`shade-test-<slug>.<account>`) and the Phala app name, so independent runs
+(e.g. on different PRs) never collide.
+
+`test-script.js` always tears down what it provisions when the run finishes — on
+success **or** failure — so a failed run no longer leaves a paid TEE instance or
+a funded account behind: the Phala CVM is deleted, and the per-run contract
+account is deleted with its balance refunded to the parent. Both ids are written
+to `tests-in-tee/.cvm-id` and `tests-in-tee/.contract-id` so CI can clean them up
+as a backstop (the account via `teardown-account.js`) if the process is killed
+before cleanup runs.
 
 ## Running in CI
 

--- a/tests-in-tee/teardown-account.js
+++ b/tests-in-tee/teardown-account.js
@@ -39,11 +39,7 @@ export async function deleteContractAccount(account, beneficiaryId) {
     console.log(`✓ Contract account ${accountId} torn down`);
     clearSentinel();
   } catch (e) {
-    // Only a genuinely-missing account counts as already-gone — match the
-    // structured error type first (as createContractAccount does), then the RPC
-    // message variants. AccessKeyDoesNotExist is deliberately excluded: the
-    // account may still exist (with funds) while this signer just lacks its key,
-    // and clearing the sentinel would strand the cleanup.
+    // Only a genuinely-missing account counts as already-gone 
     const msg = e?.message ?? String(e);
     const gone =
       e?.type === "AccountDoesNotExist" ||

--- a/tests-in-tee/teardown-account.js
+++ b/tests-in-tee/teardown-account.js
@@ -72,6 +72,15 @@ if (invokedDirectly) {
     console.error("Missing TESTNET_ACCOUNT_ID / TESTNET_PRIVATE_KEY");
     process.exit(1);
   }
+  // The backstop runs with a privileged key on an id read from the workspace
+  // .contract-id file, so only ever delete a per-run test subaccount of
+  // TESTNET_ACCOUNT_ID — never the parent or an unrelated account.
+  if (!accountId.startsWith("shade-test-") || !accountId.endsWith(`.${beneficiaryId}`)) {
+    console.error(
+      `Refusing to delete "${accountId}": expected a shade-test-<slug>.${beneficiaryId} subaccount.`,
+    );
+    process.exit(1);
+  }
   const provider = new JsonRpcProvider(
     { url: "https://test.rpc.fastnear.com" },
     { retries: 3, backoff: 2, wait: 1000 },

--- a/tests-in-tee/teardown-account.js
+++ b/tests-in-tee/teardown-account.js
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+
+/**
+ * Delete a per-run test contract account, refunding its remaining balance to
+ * the parent (TESTNET_ACCOUNT_ID). Used by test-script.js's teardown `finally`
+ * and, as a CLI, by the CI backstop step that runs if the runner was killed
+ * before that `finally` could run:
+ *
+ *   node teardown-account.js <accountId>
+ */
+
+import { fileURLToPath } from "url";
+import { dirname, resolve } from "path";
+import fs from "fs";
+import { Account } from "@near-js/accounts";
+import { KeyPairSigner } from "@near-js/signers";
+import { JsonRpcProvider } from "@near-js/providers";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// Delete `accountId`, sending its remaining balance to `beneficiaryId`.
+// Idempotent (an already-gone account counts as success) and never throws —
+// teardown runs in a finally and must never mask the real failure. Removes the
+// persisted .contract-id on success so a backstop won't try again.
+export async function deleteContractAccount(account, accountId, beneficiaryId) {
+  if (!accountId) return;
+  console.log(`\nTearing down contract account ${accountId}...`);
+  const clearSentinel = () =>
+    fs.rmSync(resolve(__dirname, ".contract-id"), { force: true });
+  try {
+    await account.deleteAccount(beneficiaryId);
+    console.log(`✓ Contract account ${accountId} torn down`);
+    clearSentinel();
+  } catch (e) {
+    const msg = e?.message ?? String(e);
+    if (/(does ?n[o']t exist|AccountDoesNotExist|UnknownAccount|AccessKeyDoesNotExist)/i.test(msg)) {
+      console.log(`✓ Contract account ${accountId} already gone`);
+      clearSentinel();
+    } else {
+      console.error(`⚠ Failed to tear down contract account ${accountId}: ${msg}`);
+    }
+  }
+}
+
+// CLI entry (CI backstop): build an Account from env + arg and delete it.
+const invokedDirectly =
+  process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+if (invokedDirectly) {
+  const accountId = process.argv[2];
+  const beneficiaryId = process.env.TESTNET_ACCOUNT_ID;
+  const privateKey = process.env.TESTNET_PRIVATE_KEY;
+  if (!accountId) {
+    console.error("Usage: node teardown-account.js <accountId>");
+    process.exit(1);
+  }
+  if (!beneficiaryId || !privateKey) {
+    console.error("Missing TESTNET_ACCOUNT_ID / TESTNET_PRIVATE_KEY");
+    process.exit(1);
+  }
+  const provider = new JsonRpcProvider({ url: "https://test.rpc.fastnear.com" });
+  const signer = KeyPairSigner.fromSecretKey(privateKey);
+  const account = new Account(accountId, provider, signer);
+  await deleteContractAccount(account, accountId, beneficiaryId);
+}

--- a/tests-in-tee/teardown-account.js
+++ b/tests-in-tee/teardown-account.js
@@ -22,7 +22,8 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 // Idempotent (an already-gone account counts as success) and never throws —
 // teardown runs in a finally and must never mask the real failure. Removes the
 // persisted .contract-id on success so a backstop won't try again.
-export async function deleteContractAccount(account, accountId, beneficiaryId) {
+export async function deleteContractAccount(account, beneficiaryId) {
+  const accountId = account?.accountId;
   if (!accountId) return;
   console.log(`\nTearing down contract account ${accountId}...`);
   // Swallows its own error so deleteContractAccount keeps its no-throw contract.
@@ -77,5 +78,5 @@ if (invokedDirectly) {
   );
   const signer = KeyPairSigner.fromSecretKey(privateKey);
   const account = new Account(accountId, provider, signer);
-  await deleteContractAccount(account, accountId, beneficiaryId);
+  await deleteContractAccount(account, beneficiaryId);
 }

--- a/tests-in-tee/teardown-account.js
+++ b/tests-in-tee/teardown-account.js
@@ -25,15 +25,29 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 export async function deleteContractAccount(account, accountId, beneficiaryId) {
   if (!accountId) return;
   console.log(`\nTearing down contract account ${accountId}...`);
-  const clearSentinel = () =>
-    fs.rmSync(resolve(__dirname, ".contract-id"), { force: true });
+  // Swallows its own error so deleteContractAccount keeps its no-throw contract.
+  const clearSentinel = () => {
+    try {
+      fs.rmSync(resolve(__dirname, ".contract-id"), { force: true });
+    } catch (e) {
+      console.error(`⚠ Could not remove .contract-id: ${e.message}`);
+    }
+  };
   try {
     await account.deleteAccount(beneficiaryId);
     console.log(`✓ Contract account ${accountId} torn down`);
     clearSentinel();
   } catch (e) {
+    // Only a genuinely-missing account counts as already-gone — match the
+    // structured error type first (as createContractAccount does), then the RPC
+    // message variants. AccessKeyDoesNotExist is deliberately excluded: the
+    // account may still exist (with funds) while this signer just lacks its key,
+    // and clearing the sentinel would strand the cleanup.
     const msg = e?.message ?? String(e);
-    if (/(does ?n[o']t exist|AccountDoesNotExist|UnknownAccount|AccessKeyDoesNotExist)/i.test(msg)) {
+    const gone =
+      e?.type === "AccountDoesNotExist" ||
+      /AccountDoesNotExist|does ?n[o']t exist|UnknownAccount/i.test(msg);
+    if (gone) {
       console.log(`✓ Contract account ${accountId} already gone`);
       clearSentinel();
     } else {
@@ -57,7 +71,10 @@ if (invokedDirectly) {
     console.error("Missing TESTNET_ACCOUNT_ID / TESTNET_PRIVATE_KEY");
     process.exit(1);
   }
-  const provider = new JsonRpcProvider({ url: "https://test.rpc.fastnear.com" });
+  const provider = new JsonRpcProvider(
+    { url: "https://test.rpc.fastnear.com" },
+    { retries: 3, backoff: 2, wait: 1000 },
+  );
   const signer = KeyPairSigner.fromSecretKey(privateKey);
   const account = new Account(accountId, provider, signer);
   await deleteContractAccount(account, accountId, beneficiaryId);

--- a/tests-in-tee/test-script.js
+++ b/tests-in-tee/test-script.js
@@ -55,13 +55,24 @@ if (!TESTNET_ACCOUNT_ID || !TESTNET_PRIVATE_KEY || !PHALA_API_KEY) {
 // Phala Cloud SDK client (same SDK the CLI deploy path uses)
 const phalaClient = createClient({ apiKey: PHALA_API_KEY });
 
-// Random per-run slug (8 bytes / 64-bit) so overlapping runs (e.g. on different
-// PRs) are extremely unlikely to collide on the contract account or Phala app name.
-const RUN_SLUG = randomBytes(8).toString("hex");
+// Random per-run slug (6 bytes / 48-bit) so overlapping runs (e.g. on different
+// PRs) are extremely unlikely to collide on the contract account or Phala app name,
+// while keeping the derived account id well within NEAR's 64-char limit.
+const RUN_SLUG = randomBytes(6).toString("hex");
 
 // Generate contract ID as subaccount of TESTNET_ACCOUNT_ID
 const AGENT_CONTRACT_ID = `shade-test-${RUN_SLUG}.${TESTNET_ACCOUNT_ID}`;
 const TEST_APP_NAME = `shade-integration-tests-${RUN_SLUG}`;
+
+// Fail fast if TESTNET_ACCOUNT_ID is long enough to push the derived subaccount
+// past NEAR's 64-char account-id limit (otherwise createAccount fails later with
+// an opaque RPC error).
+if (AGENT_CONTRACT_ID.length > 64) {
+  console.error(
+    `Derived contract account id is ${AGENT_CONTRACT_ID.length} chars, over NEAR's 64-char limit:\n  ${AGENT_CONTRACT_ID}\nUse a shorter TESTNET_ACCOUNT_ID.`,
+  );
+  process.exit(1);
+}
 
 // Toggle to skip redeploying account, contract, and initialization (useful for reusing existing deployment)
 const SKIP_CONTRACT_DEPLOYMENT = false;

--- a/tests-in-tee/test-script.js
+++ b/tests-in-tee/test-script.js
@@ -1400,11 +1400,7 @@ async function main() {
     // (refunding the parent). Neither teardown throws.
     await deletePhalaApp(appId);
     if (createdContract) {
-      await deleteContractAccount(
-        contractAccount,
-        AGENT_CONTRACT_ID,
-        TESTNET_ACCOUNT_ID,
-      );
+      await deleteContractAccount(contractAccount, TESTNET_ACCOUNT_ID);
     }
   }
 }

--- a/tests-in-tee/test-script.js
+++ b/tests-in-tee/test-script.js
@@ -55,9 +55,9 @@ if (!TESTNET_ACCOUNT_ID || !TESTNET_PRIVATE_KEY || !PHALA_API_KEY) {
 // Phala Cloud SDK client (same SDK the CLI deploy path uses)
 const phalaClient = createClient({ apiKey: PHALA_API_KEY });
 
-// Random per-run slug so overlapping runs (e.g. on different PRs) don't collide
-// on the contract account or the Phala app name.
-const RUN_SLUG = randomBytes(4).toString("hex");
+// Random per-run slug (8 bytes / 64-bit) so overlapping runs (e.g. on different
+// PRs) are extremely unlikely to collide on the contract account or Phala app name.
+const RUN_SLUG = randomBytes(8).toString("hex");
 
 // Generate contract ID as subaccount of TESTNET_ACCOUNT_ID
 const AGENT_CONTRACT_ID = `shade-test-${RUN_SLUG}.${TESTNET_ACCOUNT_ID}`;
@@ -143,11 +143,12 @@ const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
 // On the normal per-run path createAccount is the one transaction signed by the
 // shared parent key — the contract account is its own owner, so every owner/admin
-// call runs on that account's independent nonce (only the account-reuse branch's
-// transfer top-up is also parent-signed, and a fresh random slug makes that branch
-// unreachable). Concurrent runs can still race the parent's nonce on createAccount,
-// so retry on a nonce conflict (each attempt re-queries the access key, picking up
-// the new nonce). Jittered so two runs don't retry in lockstep.
+// call runs on that account's independent nonce. (The account-reuse branch's
+// transfer top-up is also parent-signed, but a fresh random slug means that branch
+// only runs in the rare case the subaccount already exists.) Concurrent runs can
+// still race the parent's nonce on createAccount, so retry on a nonce conflict (each
+// attempt re-queries the access key, picking up the new nonce). Jittered so two runs
+// don't retry in lockstep.
 async function createAccountWithNonceRetry(newAccountId, publicKey, amount) {
   const maxAttempts = 5;
   for (let attempt = 1; ; attempt++) {

--- a/tests-in-tee/test-script.js
+++ b/tests-in-tee/test-script.js
@@ -141,12 +141,13 @@ const contractAccount = new Account(AGENT_CONTRACT_ID, provider, signer);
 // Sleep helper
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
-// createAccount is the only transaction signed by the shared parent key — the
-// per-run contract account is its own owner, so every other owner/admin call
-// runs on that account's independent nonce. Concurrent runs can still race the
-// parent's nonce on this one tx, so retry on a nonce conflict (each attempt
-// re-queries the access key, picking up the new nonce). Jittered so two runs
-// don't retry in lockstep.
+// On the normal per-run path createAccount is the one transaction signed by the
+// shared parent key — the contract account is its own owner, so every owner/admin
+// call runs on that account's independent nonce (only the account-reuse branch's
+// transfer top-up is also parent-signed, and a fresh random slug makes that branch
+// unreachable). Concurrent runs can still race the parent's nonce on createAccount,
+// so retry on a nonce conflict (each attempt re-queries the access key, picking up
+// the new nonce). Jittered so two runs don't retry in lockstep.
 async function createAccountWithNonceRetry(newAccountId, publicKey, amount) {
   const maxAttempts = 5;
   for (let attempt = 1; ; attempt++) {
@@ -156,7 +157,7 @@ async function createAccountWithNonceRetry(newAccountId, publicKey, amount) {
     } catch (e) {
       const msg = e?.message ?? String(e);
       if (attempt < maxAttempts && /nonce/i.test(msg)) {
-        console.log(`Nonce conflict creating account, retrying (${attempt}/${maxAttempts - 1})`);
+        console.log(`Nonce conflict creating account (attempt ${attempt} of ${maxAttempts}), retrying`);
         await sleep(300 + attempt * 400 + Math.floor(Math.random() * 400));
         continue;
       }

--- a/tests-in-tee/test-script.js
+++ b/tests-in-tee/test-script.js
@@ -56,7 +56,7 @@ if (!TESTNET_ACCOUNT_ID || !TESTNET_PRIVATE_KEY || !PHALA_API_KEY) {
 const phalaClient = createClient({ apiKey: PHALA_API_KEY });
 
 // Random per-run slug (6 bytes / 48-bit) so overlapping runs (e.g. on different
-// PRs) are extremely unlikely to collide on the contract account or Phala app name,
+// PRs) don't collide on the contract account or Phala app name,
 // while keeping the derived account id well within NEAR's 64-char limit.
 const RUN_SLUG = randomBytes(6).toString("hex");
 
@@ -65,21 +65,13 @@ const AGENT_CONTRACT_ID = `shade-test-${RUN_SLUG}.${TESTNET_ACCOUNT_ID}`;
 const TEST_APP_NAME = `shade-integration-tests-${RUN_SLUG}`;
 
 // Fail fast if TESTNET_ACCOUNT_ID is long enough to push the derived subaccount
-// past NEAR's 64-char account-id limit (otherwise createAccount fails later with
-// an opaque RPC error).
+// past NEAR's 64-char account-id limit .
 if (AGENT_CONTRACT_ID.length > 64) {
   console.error(
     `Derived contract account id is ${AGENT_CONTRACT_ID.length} chars, over NEAR's 64-char limit:\n  ${AGENT_CONTRACT_ID}\nUse a shorter TESTNET_ACCOUNT_ID.`,
   );
   process.exit(1);
 }
-
-// Toggle to skip redeploying account, contract, and initialization (useful for reusing existing deployment)
-const SKIP_CONTRACT_DEPLOYMENT = false;
-
-// Toggle to skip Phala deployment - ON if TEST_APP_URL is specified, OFF if empty
-// const TEST_APP_URL = "https://45034fea45a406a829feea099c77bbe6cf26faed-3000.dstack-pha-prod7.phala.network";
-const SKIP_PHALA_DEPLOYMENT = false;
 
 // Write AGENT_CONTRACT_ID to .env file for docker-compose
 function updateEnvFile() {
@@ -170,7 +162,7 @@ async function createAccountWithNonceRetry(newAccountId, publicKey, amount) {
       const msg = e?.message ?? String(e);
       if (attempt < maxAttempts && /nonce/i.test(msg)) {
         console.log(`Nonce conflict creating account (attempt ${attempt} of ${maxAttempts}), retrying`);
-        await sleep(300 + attempt * 400 + Math.floor(Math.random() * 400));
+        await sleep(300 + attempt * 400 + Math.floor(Math.random() * 2000));
         continue;
       }
       throw e;
@@ -1320,55 +1312,41 @@ async function main() {
   // Phala TEE instance or a funded testnet account.
   let appUrl;
   let appId = null;
-  let createdContract = false;
   try {
-    // Deploy contract to testnet (skip if SKIP_CONTRACT_DEPLOYMENT is true)
-    if (!SKIP_CONTRACT_DEPLOYMENT) {
-      console.log("\nDeploying contract to testnet...");
-      // Mark + persist the account id before creating it, so a CI teardown
-      // step can delete it even if this process is killed mid-create.
-      createdContract = true;
-      try {
-        fs.writeFileSync(resolve(__dirname, ".contract-id"), AGENT_CONTRACT_ID);
-      } catch (e) {
-        console.error(`⚠ Could not write .contract-id: ${e.message}`);
-      }
-      await createContractAccount();
-      await deployContract();
-      await initializeContract();
-      console.log("✓ Contract deployment complete\n");
-    } else {
-      console.log(
-        "\n⚠ Skipping contract deployment (SKIP_CONTRACT_DEPLOYMENT=true)\n",
-      );
+    // Deploy contract to testnet.
+    console.log("\nDeploying contract to testnet...");
+    // Persist the account id before creating it, so a CI teardown step can
+    // delete it even if this process is killed mid-create.
+    try {
+      fs.writeFileSync(resolve(__dirname, ".contract-id"), AGENT_CONTRACT_ID);
+    } catch (e) {
+      console.error(`⚠ Could not write .contract-id: ${e.message}`);
     }
+    await createContractAccount();
+    await deployContract();
+    await initializeContract();
+    console.log("✓ Contract deployment complete\n");
 
-    if (SKIP_PHALA_DEPLOYMENT) {
-      console.log("⚠ Skipping Phala deployment (TEST_APP_URL provided)");
-      appUrl = TEST_APP_URL.trim();
-      console.log(`✓ Using provided app URL: ${appUrl}`);
-    } else {
-      // Build, push, and update docker-compose.yaml with the test image
-      console.log("\nBuilding and pushing test image...");
-      await buildAndPushTestImage();
-      console.log("✓ Test image built and pushed\n");
+    // Build, push, and update docker-compose.yaml with the test image
+    console.log("\nBuilding and pushing test image...");
+    await buildAndPushTestImage();
+    console.log("✓ Test image built and pushed\n");
 
-      console.log("Deploying test image to Phala...");
-      appId = await deployToPhala();
-      // Persist the CVM id so a CI teardown step can delete it even if this
-      // process is killed before the `finally` below runs.
-      try {
-        fs.writeFileSync(resolve(__dirname, ".cvm-id"), String(appId));
-      } catch (e) {
-        console.error(`⚠ Could not write .cvm-id: ${e.message}`);
-      }
-      const appUrls = await getAppUrl(appId);
-      if (!appUrls || appUrls.length === 0) {
-        throw new Error("Failed to get app URL from Phala");
-      }
-      appUrl = appUrls[0].app;
-      console.log(`✓ App deployed at: ${appUrl}`);
+    console.log("Deploying test image to Phala...");
+    appId = await deployToPhala();
+    // Persist the CVM id so a CI teardown step can delete it even if this
+    // process is killed before the `finally` below runs.
+    try {
+      fs.writeFileSync(resolve(__dirname, ".cvm-id"), String(appId));
+    } catch (e) {
+      console.error(`⚠ Could not write .cvm-id: ${e.message}`);
     }
+    const appUrls = await getAppUrl(appId);
+    if (!appUrls || appUrls.length === 0) {
+      throw new Error("Failed to get app URL from Phala");
+    }
+    appUrl = appUrls[0].app;
+    console.log(`✓ App deployed at: ${appUrl}`);
 
     // Wait for the app to be ready using heartbeat
     await waitForAppReady(appUrl);
@@ -1407,13 +1385,12 @@ async function main() {
 
     console.log("\n✓ All tests passed!");
   } finally {
-    // Tear down the CVM we provisioned (no-op when a provided endpoint was
-    // reused, i.e. appId is null), then delete the per-run contract account
-    // (refunding the parent). Neither teardown throws.
+    // Tear down what this run provisioned: the Phala CVM, then the per-run
+    // contract account (refunding the parent). Both are idempotent and neither
+    // throws, so this is safe even if an early failure left them half-created
+    // (appId stays null until the CVM exists, making deletePhalaApp a no-op).
     await deletePhalaApp(appId);
-    if (createdContract) {
-      await deleteContractAccount(contractAccount, TESTNET_ACCOUNT_ID);
-    }
+    await deleteContractAccount(contractAccount, TESTNET_ACCOUNT_ID);
   }
 }
 

--- a/tests-in-tee/test-script.js
+++ b/tests-in-tee/test-script.js
@@ -10,6 +10,7 @@
  */
 
 import { execSync } from "child_process";
+import { randomBytes } from "crypto";
 import { fileURLToPath } from "url";
 import path, { dirname, resolve } from "path";
 import fs from "fs";
@@ -29,6 +30,7 @@ import { getPpids } from "../shade-agent-cli/src/utils/ppids.js";
 import { tgasToGas } from "../shade-agent-cli/src/utils/near.js";
 import { deployToPhala as deployToPhalaSdk, createClient } from "../shade-agent-cli/src/utils/phala-deploy.js";
 import { wipeContractState } from "../shade-agent-cli/src/utils/state-cleanup.js";
+import { deleteContractAccount } from "./teardown-account.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -53,9 +55,13 @@ if (!TESTNET_ACCOUNT_ID || !TESTNET_PRIVATE_KEY || !PHALA_API_KEY) {
 // Phala Cloud SDK client (same SDK the CLI deploy path uses)
 const phalaClient = createClient({ apiKey: PHALA_API_KEY });
 
+// Random per-run slug so overlapping runs (e.g. on different PRs) don't collide
+// on the contract account or the Phala app name.
+const RUN_SLUG = randomBytes(4).toString("hex");
+
 // Generate contract ID as subaccount of TESTNET_ACCOUNT_ID
-const AGENT_CONTRACT_ID = `shade-test-contract.${TESTNET_ACCOUNT_ID}`;
-const TEST_APP_NAME = "shade-integration-tests";
+const AGENT_CONTRACT_ID = `shade-test-${RUN_SLUG}.${TESTNET_ACCOUNT_ID}`;
+const TEST_APP_NAME = `shade-integration-tests-${RUN_SLUG}`;
 
 // Toggle to skip redeploying account, contract, and initialization (useful for reusing existing deployment)
 const SKIP_CONTRACT_DEPLOYMENT = false;
@@ -135,6 +141,30 @@ const contractAccount = new Account(AGENT_CONTRACT_ID, provider, signer);
 // Sleep helper
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
+// createAccount is the only transaction signed by the shared parent key — the
+// per-run contract account is its own owner, so every other owner/admin call
+// runs on that account's independent nonce. Concurrent runs can still race the
+// parent's nonce on this one tx, so retry on a nonce conflict (each attempt
+// re-queries the access key, picking up the new nonce). Jittered so two runs
+// don't retry in lockstep.
+async function createAccountWithNonceRetry(newAccountId, publicKey, amount) {
+  const maxAttempts = 5;
+  for (let attempt = 1; ; attempt++) {
+    try {
+      await account.createAccount(newAccountId, publicKey, amount);
+      return;
+    } catch (e) {
+      const msg = e?.message ?? String(e);
+      if (attempt < maxAttempts && /nonce/i.test(msg)) {
+        console.log(`Nonce conflict creating account, retrying (${attempt}/${maxAttempts - 1})`);
+        await sleep(300 + attempt * 400 + Math.floor(Math.random() * 400));
+        continue;
+      }
+      throw e;
+    }
+  }
+}
+
 // Create contract account (as subaccount of TESTNET_ACCOUNT_ID)
 async function createContractAccount() {
   console.log("Creating contract account...");
@@ -209,7 +239,7 @@ async function createContractAccount() {
   console.log("Contract account does not exist, creating it");
   try {
     const publicKey = await account.getSigner().getPublicKey();
-    await account.createAccount(
+    await createAccountWithNonceRetry(
       AGENT_CONTRACT_ID,
       publicKey,
       NEAR.toUnits(fundingAmount),
@@ -256,7 +286,9 @@ async function initializeContract() {
   const initArgs = {
     requires_tee: true,
     attestation_expiration_time_ms: "100000", // 100 seconds in milliseconds (as U64 string)
-    owner_id: TESTNET_ACCOUNT_ID,
+    // The contract owns itself so owner-gated calls are signed by the contract
+    // account (its own nonce), not the shared parent key — lets runs overlap.
+    owner_id: AGENT_CONTRACT_ID,
     mpc_contract_id: "v1.signer-prod.testnet", // testnet MPC contract
   };
 
@@ -467,7 +499,7 @@ async function getAppUrl(appId) {
 // Approve measurements
 async function approveMeasurements(measurements) {
   console.log("Approving measurements...");
-  await account.callFunction({
+  await contractAccount.callFunction({
     contractId: AGENT_CONTRACT_ID,
     methodName: "approve_measurements",
     args: { measurements },
@@ -478,7 +510,7 @@ async function approveMeasurements(measurements) {
 // Remove measurements
 async function removeMeasurements(measurements) {
   console.log("Removing measurements...");
-  await account.callFunction({
+  await contractAccount.callFunction({
     contractId: AGENT_CONTRACT_ID,
     methodName: "remove_measurements",
     args: { measurements },
@@ -489,7 +521,7 @@ async function removeMeasurements(measurements) {
 // Approve PPIDs
 async function approvePpids(ppids) {
   console.log("Approving PPIDs...");
-  await account.callFunction({
+  await contractAccount.callFunction({
     contractId: AGENT_CONTRACT_ID,
     methodName: "approve_ppids",
     args: { ppids },
@@ -500,7 +532,7 @@ async function approvePpids(ppids) {
 // Remove PPIDs
 async function removePpids(ppids) {
   console.log("Removing PPIDs...");
-  await account.callFunction({
+  await contractAccount.callFunction({
     contractId: AGENT_CONTRACT_ID,
     methodName: "remove_ppids",
     args: { ppids },
@@ -512,7 +544,7 @@ async function removePpids(ppids) {
 async function updateAttestationExpirationTime(ms) {
   const msStr = String(ms);
   console.log(`Updating attestation expiration to ${msStr} ms...`);
-  await account.callFunction({
+  await contractAccount.callFunction({
     contractId: AGENT_CONTRACT_ID,
     methodName: "update_attestation_expiration_time",
     args: { attestation_expiration_time_ms: msStr },
@@ -1269,25 +1301,35 @@ async function main() {
   // Update .env file with generated contract ID
   updateEnvFile();
 
-  // Deploy contract to testnet (skip if SKIP_CONTRACT_DEPLOYMENT is true)
-  if (!SKIP_CONTRACT_DEPLOYMENT) {
-    console.log("\nDeploying contract to testnet...");
-    await createContractAccount();
-    await deployContract();
-    await initializeContract();
-    console.log("✓ Contract deployment complete\n");
-  } else {
-    console.log(
-      "\n⚠ Skipping contract deployment (SKIP_CONTRACT_DEPLOYMENT=true)\n",
-    );
-  }
-
-  // Deploy to Phala (or use a provided endpoint) and run the tests. The whole
-  // block is wrapped so the `finally` always tears down the CVM we provisioned,
-  // on success or failure, to avoid leaking a paid Phala TEE instance.
+  // Deploy to Phala and run the tests. The whole block is wrapped so the
+  // `finally` always tears down the CVM and the contract account this run
+  // provisioned, on success or failure, so overlapping runs don't leak a paid
+  // Phala TEE instance or a funded testnet account.
   let appUrl;
   let appId = null;
+  let createdContract = false;
   try {
+    // Deploy contract to testnet (skip if SKIP_CONTRACT_DEPLOYMENT is true)
+    if (!SKIP_CONTRACT_DEPLOYMENT) {
+      console.log("\nDeploying contract to testnet...");
+      // Mark + persist the account id before creating it, so a CI teardown
+      // step can delete it even if this process is killed mid-create.
+      createdContract = true;
+      try {
+        fs.writeFileSync(resolve(__dirname, ".contract-id"), AGENT_CONTRACT_ID);
+      } catch (e) {
+        console.error(`⚠ Could not write .contract-id: ${e.message}`);
+      }
+      await createContractAccount();
+      await deployContract();
+      await initializeContract();
+      console.log("✓ Contract deployment complete\n");
+    } else {
+      console.log(
+        "\n⚠ Skipping contract deployment (SKIP_CONTRACT_DEPLOYMENT=true)\n",
+      );
+    }
+
     if (SKIP_PHALA_DEPLOYMENT) {
       console.log("⚠ Skipping Phala deployment (TEST_APP_URL provided)");
       appUrl = TEST_APP_URL.trim();
@@ -1353,8 +1395,16 @@ async function main() {
     console.log("\n✓ All tests passed!");
   } finally {
     // Tear down the CVM we provisioned (no-op when a provided endpoint was
-    // reused, i.e. appId is null). deletePhalaApp never throws.
+    // reused, i.e. appId is null), then delete the per-run contract account
+    // (refunding the parent). Neither teardown throws.
     await deletePhalaApp(appId);
+    if (createdContract) {
+      await deleteContractAccount(
+        contractAccount,
+        AGENT_CONTRACT_ID,
+        TESTNET_ACCOUNT_ID,
+      );
+    }
   }
 }
 


### PR DESCRIPTION
## What & why

The `tests-in-tee` e2e suite (`/run-e2e`) bakes fixed, global names into each run — the NEAR contract account `shade-test-contract.<parent>` and the Phala app name — so two runs that overlap (e.g. `/run-e2e` on two PRs at once) clobber each other's contract state. This makes the suite safe to run concurrently.

## Changes

- **Unique per-run names.** A random per-run slug drives the contract account (`shade-test-<slug>.<parent>`) and the Phala app name, so different runs never collide on either.
- **No shared-key nonce contention.** The contract is initialised as its own owner, so owner-gated calls (`approve_`/`remove_measurements`, `approve_`/`remove_ppids`, `update_attestation_expiration_time`) sign with the contract account's *independent* nonce instead of the shared parent key. The only remaining parent-key tx — `createAccount` — retries on a nonce conflict.
- **Per-run account lifecycle.** Each run creates and tears down its own funded subaccount, refunding the balance to the parent (mirrors the existing CVM teardown). The id is persisted to `.contract-id` with an `always()` CI backstop (`teardown-account.js`) for killed runners, symmetric with `.cvm-id`.
- **Docker untouched.** Deploys are pinned by the image `@sha256:` digest each run extracts from its own push, so the shared `:latest` tag never causes a cross-run collision — no per-run tag or registry deletion needed.
- Docs + `.gitignore` updated; note the ~10 NEAR-per-concurrent-run parent balance.

No contract change is needed: `require_owner` is just `predecessor_account_id == owner_id`, so owner-as-self passes.

## Release impact

None — `tests-in-tee` is not a published package; only the test harness, the e2e workflow, and docs change.

## Test plan

- ✅ `node --check` on `test-script.js` + `teardown-account.js`; workflow YAML parses; owner calls confirmed routed through the contract account.
- ⏳ End-to-end needs `PHALA_API_KEY` + a funded testnet account: run `cd tests-in-tee && npm run test` (ideally two at once), or `/run-e2e` on two PRs simultaneously. Expect per-run `shade-test-<slug>.<parent>` / `shade-integration-tests-<slug>`, both passing, each tearing down its CVM **and** account (refund to parent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
