### PR TITLE
ci(dependabot): cover tests-in-tee and contract-builder manifests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -62,6 +62,46 @@ updates:
         update-types:
           - "minor"
 
+  - package-ecosystem: npm
+    directory: /tests-in-tee
+    schedule:
+      interval: weekly
+    versioning-strategy: increase
+    open-pull-requests-limit: 5
+    cooldown:
+      default-days: 10
+    groups:
+      patch:
+        patterns:
+          - "*"
+        update-types:
+          - "patch"
+      minor:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+
+  - package-ecosystem: npm
+    directory: /tests-in-tee/test-image
+    schedule:
+      interval: weekly
+    versioning-strategy: increase
+    open-pull-requests-limit: 5
+    cooldown:
+      default-days: 10
+    groups:
+      patch:
+        patterns:
+          - "*"
+        update-types:
+          - "patch"
+      minor:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+
   # Rust crates
   - package-ecosystem: cargo
     directory: /shade-attestation
@@ -103,6 +143,24 @@ updates:
 
   - package-ecosystem: docker
     directory: /
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 7
+    groups:
+      patch:
+        patterns:
+          - "*"
+        update-types:
+          - "patch"
+      minor:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+
+  - package-ecosystem: docker
+    directory: /contract-builder
     schedule:
       interval: weekly
     cooldown:


### PR DESCRIPTION
## What

Make every manifest that's built in CI a first-class Dependabot citizen. Adds three update blocks (10 total now):

- **npm** `/tests-in-tee`
- **npm** `/tests-in-tee/test-image`
- **docker** `/contract-builder`

Each new block mirrors the existing block for its ecosystem (weekly schedule, `versioning-strategy: increase` for npm, the same cooldown and patch/minor groups).

## Why

`tests-in-tee` and `tests-in-tee/test-image` run in CI but had no Dependabot **version-update** config, so they only ever got security *alerts*, never automated bump PRs. `contract-builder/Dockerfile` lives in a subdirectory, and the existing `docker: /` block doesn't recurse, so its base image was uncovered.

After this, version-update coverage matches what the dependency graph already alerts on:

| Ecosystem | Directories covered |
|---|---|
| npm | shade-agent-cli, shade-agent-js, shade-agent-template, **tests-in-tee**, **tests-in-tee/test-image** |
| cargo | shade-attestation, shade-contract-template |
| docker | `/`, **/contract-builder** |
| github-actions | `/` |

## Release impact

None — CI/tooling config only (`.github/dependabot.yml`); no published package changes.