### PR TITLE
chore(template): drop obsolete @noble/curves override

### DIFF
--- a/shade-agent-template/package-lock.json
+++ b/shade-agent-template/package-lock.json
@@ -45,10 +45,10 @@
       },
       "devDependencies": {
         "@types/node": "25.9.3",
-        "@vitest/coverage-v8": "4.1.8",
+        "@vitest/coverage-v8": "4.1.9",
         "tsup": "8.5.1",
         "typescript": "6.0.3",
-        "vitest": "4.1.8"
+        "vitest": "4.1.9"
       },
       "engines": {
         "node": ">=22"
@@ -3989,6 +3989,21 @@
         "node": ">=18"
       }
     },
+    "node_modules/@mysten/sui/node_modules/@noble/curves": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.4.tgz",
+      "integrity": "sha512-2bKONnuM53lINoDrSmK8qP8W271ms7pygDhZt4SiLOoLwBtoHqeCFi6RG42V8zd3mLHuJFhU/Bmaqo4nX0/kBw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@mysten/utils": {
       "version": "0.2.0",
       "license": "Apache-2.0",
@@ -4050,6 +4065,33 @@
       "peerDependencies": {
         "@near-js/types": "^2.0.1",
         "@near-js/utils": "^2.0.1"
+      }
+    },
+    "node_modules/@near-js/crypto/node_modules/@noble/curves": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.8.1.tgz",
+      "integrity": "sha512-warwspo+UYUPep0Q+vtdVB4Ugn8GGQj8iyB3gnRWsztmUHTI3S1nhdiWNsPUGL0vud7JlRRk1XEu7Lq1KGTnMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.7.1"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@near-js/crypto/node_modules/@noble/hashes": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.7.1.tgz",
+      "integrity": "sha512-B8XBPsn4vT/KJAGqDzbwztd+6Yte3P4V7iafm24bxgDe/mlRuK6xmWPuCNrKt2vDafZ8MfJLlchDG/vYafQEjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@near-js/keystores": {
@@ -5069,6 +5111,18 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/ethers/node_modules/@noble/curves": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
+      "integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.3.2"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/ethers/node_modules/@noble/hashes": {
       "version": "1.3.2",
       "license": "MIT",
@@ -5697,6 +5751,21 @@
       "version": "1.11.1",
       "license": "MIT"
     },
+    "node_modules/ox/node_modules/@noble/curves": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.1.tgz",
+      "integrity": "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/ox/node_modules/eventemitter3": {
       "version": "5.0.1",
       "license": "MIT"
@@ -6024,6 +6093,21 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/viem/node_modules/@noble/curves": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.1.tgz",
+      "integrity": "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/viem/node_modules/ws": {

--- a/shade-agent-template/package.json
+++ b/shade-agent-template/package.json
@@ -27,8 +27,5 @@
   "devDependencies": {
     "@types/node": "20.19.39",
     "typescript": "5.9.3"
-  },
-  "overrides": {
-    "@noble/curves": "1.9.7"
   }
 }


### PR DESCRIPTION
## What

Removes the `@noble/curves@1.9.7` override from `shade-agent-template`.

## Why

The override (added in #57) was a band-aid for `chainsig.js@1.1.15` not declaring its `@noble/curves` dependency — without it the resolver hoisted `1.8.1`, which lacks the `./utils` subpath chainsig.js imports, crashing the agent on TEE rebuild.

`chainsig.js@1.1.16` (the current pin) now declares `@noble/curves: ^1.9.0`, so it resolves its own `1.9.x` copy with `./utils`. The override is no longer needed — and it had been forcing `ethers` (declares `1.2.0`), `@near-js/crypto` (`1.8.1`) and `viem` (`1.9.1`) onto `1.9.7`, versions they weren't tested against. Removing it lets each consumer use its declared range.

## Verification

- `npm ls @noble/curves`: chainsig.js → top-level `1.9.7` (has `./utils`); `@near-js/crypto` → nested `1.8.1`; `ethers` → `1.2.0`; `viem`/`ox` → `1.9.1`.
- Import smoke test: `await import('chainsig.js')` resolves `@noble/curves/utils` with no error — the exact failure mode the override guarded against.

## Release impact

None — `shade-agent-template` is `private` and unpublished.
